### PR TITLE
feat: use env-based API base URL

### DIFF
--- a/.env
+++ b/.env
@@ -16,8 +16,7 @@ LOG_LEVEL=info
 LOG_DIR=logs
 
 # Configurações de API
-VITE_API_URL=http://localhost:3000/api
-VITE_API_URL_PROD=http://movemarias.squadsolucoes.com.br/api
+VITE_API_BASE_URL=http://localhost:3000/api
 
 # Database URL para migrações
 DATABASE_URL=postgresql://postgres:SenhaSegura123@localhost:5432/movemarias

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ VITE_SUPABASE_URL=https://seu-projeto.supabase.co
 VITE_SUPABASE_ANON_KEY=sua_chave_publica_supabase
 VITE_SUPABASE_SERVICE_ROLE_KEY=sua_chave_service_role
 
+# Configuração de API
+VITE_API_BASE_URL=http://localhost:3000/api
+
 # Configurações da Aplicação
 VITE_APP_NAME="Assist Move Assist"
 VITE_APP_VERSION="1.0.0"

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 # API Configuration for PostgreSQL Backend
-VITE_API_URL=http://movemarias.squadsolucoes.com.br/api
+VITE_API_BASE_URL=http://movemarias.squadsolucoes.com.br/api
 
 # Disable Supabase dummy mode
 VITE_SUPABASE_URL=

--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -311,6 +311,9 @@ VITE_SUPABASE_URL=https://seu-projeto.supabase.co
 VITE_SUPABASE_ANON_KEY=sua_chave_publica_supabase
 VITE_SUPABASE_SERVICE_ROLE_KEY=sua_chave_service_role
 
+# API
+VITE_API_BASE_URL=https://seu-dominio/api
+
 # Opcional: Monitoramento
 VITE_SENTRY_DSN=https://sua-chave@sentry.io/projeto
 VITE_LOGROCKET_APP_ID=seu-app-id
@@ -398,6 +401,7 @@ vercel --prod
   "outputDirectory": "dist",
   "installCommand": "npm install",
   "env": {
+    "VITE_API_BASE_URL": "@vite_api_base_url",
     "VITE_SUPABASE_URL": "@vite_supabase_url",
     "VITE_SUPABASE_ANON_KEY": "@vite_supabase_anon_key"
   },
@@ -439,6 +443,7 @@ vercel --prod
 # Via CLI
 vercel env add VITE_SUPABASE_URL production
 vercel env add VITE_SUPABASE_ANON_KEY production
+vercel env add VITE_API_BASE_URL production
 
 # Ou via Dashboard: vercel.com > Project > Settings > Environment Variables
 ```
@@ -453,6 +458,7 @@ vercel env add VITE_SUPABASE_ANON_KEY production
 
 [build.environment]
   NODE_VERSION = "18"
+  VITE_API_BASE_URL = "https://seu-dominio/api"
 
 [[redirects]]
   from = "/*"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -239,7 +239,7 @@ cd $FRONTEND_DIR
 
 # Atualizar configurações do frontend para produção
 cat > .env.production << EOF
-VITE_API_URL=https://$DOMAIN/api
+VITE_API_BASE_URL=https://$DOMAIN/api
 VITE_WS_URL=wss://$DOMAIN/ws
 VITE_APP_URL=https://$DOMAIN
 EOF

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,22 +1,6 @@
 // Frontend API client para comunicação com o backend PostgreSQL
 const getApiBaseUrl = () => {
-  // Detectar ambiente baseado no hostname e protocolo
-  if (typeof window !== 'undefined') {
-    const { hostname, protocol } = window.location;
-    
-    // Produção
-    if (hostname === 'movemarias.squadsolucoes.com.br') {
-      return `${protocol}//movemarias.squadsolucoes.com.br/api`;
-    }
-    
-    // Desenvolvimento local
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname.includes('codespaces')) {
-      return 'http://localhost:3000/api';
-    }
-  }
-  
-  // Fallback para desenvolvimento
-  return 'http://localhost:3000/api';
+  return import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 };
 
 const API_BASE_URL = getApiBaseUrl();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,19 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 import { componentTagger } from 'lovable-tagger';
 
-export default defineConfig(({ mode }) => ({
-  plugins: [
-    react(),
-    mode === 'development' && componentTagger(),
-  ].filter(Boolean),
-  build: {
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [
+      react(),
+      mode === 'development' && componentTagger(),
+    ].filter(Boolean),
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(env.VITE_API_BASE_URL),
+    },
+    build: {
     // Otimizações de build
     target: 'es2015',
     minify: 'terser',
@@ -63,23 +68,24 @@ export default defineConfig(({ mode }) => ({
     chunkSizeWarningLimit: 1000, // 1MB de aviso
     sourcemap: process.env.NODE_ENV === 'development'
   },
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, './src')
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 8080,
-    host: true, // Permite acesso externo
-    strictPort: true
-  },
-  preview: {
-    port: 8080,
-    host: true
-  },
-  // Otimizações de desenvolvimento
-  optimizeDeps: {
-    include: ['react', 'react-dom', 'react-router-dom'],
-    exclude: ['@vite/client', '@vite/env']
-  }
-}));
+    server: {
+      port: 8080,
+      host: true, // Permite acesso externo
+      strictPort: true,
+    },
+    preview: {
+      port: 8080,
+      host: true,
+    },
+    // Otimizações de desenvolvimento
+    optimizeDeps: {
+      include: ['react', 'react-dom', 'react-router-dom'],
+      exclude: ['@vite/client', '@vite/env'],
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add `VITE_API_BASE_URL` to environment templates
- read API base URL from `import.meta.env` and expose via Vite/TS configs
- document new variable and update deploy script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c96d0ee94832691403f2209720d01