### PR TITLE
feat: aggregate API routes and update websocket init

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,12 +5,10 @@ import compression from 'compression';
 import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import { createServer } from 'http';
-import { WebSocketServer } from 'ws';
 import dotenv from 'dotenv';
 
-import { authRoutes } from './routes/auth';
 import { apiRoutes } from './routes/api';
-import { setupWebSocket } from './routes/websocket';
+import { initializeWebSocket } from './services/websocket';
 import { errorHandler } from './middleware/errorHandler';
 import { logger } from './services/logger';
 
@@ -19,7 +17,6 @@ dotenv.config();
 
 const app = express();
 const server = createServer(app);
-const wss = new WebSocketServer({ server });
 
 // Middleware de segurança
 app.use(helmet());
@@ -56,11 +53,10 @@ app.get('/health', (req, res) => {
 });
 
 // Routes
-app.use('/api/auth', authRoutes);
 app.use('/api', apiRoutes);
 
 // WebSocket setup
-setupWebSocket(wss);
+initializeWebSocket(server);
 
 // Error handling
 app.use(errorHandler);

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import authRoutes from './auth';
+import beneficiariasRoutes from './beneficiarias';
+import dashboardRoutes from './dashboard';
+import healthRoutes from './health';
+
+const router = Router();
+
+router.use('/auth', authRoutes);
+router.use('/beneficiarias', beneficiariasRoutes);
+router.use('/dashboard', dashboardRoutes);
+router.use('/health', healthRoutes);
+
+export { router as apiRoutes };
+export default router;


### PR DESCRIPTION
## Summary
- add centralized API router combining auth, beneficiarias, dashboard and health endpoints
- update app setup to use new router and initialize websocket service

## Testing
- `npm test --prefix backend` *(fails: test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_689ca47c85d88326a16320239bbb1233