### PR TITLE
feat: add centralized error handler

### DIFF
--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import { loggerService } from '../services/logger';
+
+export const errorHandler = (err: any, req: Request, res: Response, next: NextFunction) => {
+  const traceId = randomUUID();
+  const statusCode = err.status || err.statusCode || 500;
+
+  loggerService.error(err.message || 'Unexpected error', {
+    traceId,
+    stack: err.stack,
+    path: req.path,
+    method: req.method,
+  });
+
+  const message = statusCode >= 500 ? 'Erro interno do servidor' : err.message;
+
+  res.status(statusCode).json({
+    error: message,
+    traceId,
+  });
+};


### PR DESCRIPTION
## Summary
- add centralized error handler middleware with trace IDs and logging

## Testing
- `npx jest --runInBand --passWithNoTests` *(fails: Property 'getBeneficiarias' does not exist on type 'Mocked')*

------
https://chatgpt.com/codex/tasks/task_e_689ca47dde648326b46524a82e6931e1