### PR TITLE
feat: use persistent preview server for e2e

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -57,7 +57,7 @@ export default defineConfig({
 
   // Start the application automatically for both local runs and CI.
   webServer: {
-    command: `npm run build && npm run preview -- --port ${PORT}`,
+    command: `bash -c "npm run build && npm run preview -- --port ${PORT} & pid=\\$!; npx wait-on http://127.0.0.1:${PORT} -t 180000 && wait \\$pid"`,
     url: BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 180000,


### PR DESCRIPTION
## Summary
- use bash command with wait-on to keep Vite preview server persistent for Playwright tests

## Testing
- `npm run test:e2e` *(fails: npm 403 trying to fetch wait-on)*

------
https://chatgpt.com/codex/tasks/task_e_689cd03799d48326bc86208d585cb1cf