### PR TITLE
feat: add authenticated request helper type

### DIFF
--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import type { Request, Response } from 'express';
+import type { Response } from 'express';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { loggerService } from '../services/logger';
 import { authService } from '../services';
@@ -11,6 +11,8 @@ interface RequestWithBody<T = any> {
     remoteAddress?: string;
   };
 }
+
+type AuthRequestWithBody<T> = AuthenticatedRequest & { body: T };
 
 interface LoginRequestBody {
   email: string;


### PR DESCRIPTION
## Summary
- add generic `AuthRequestWithBody` type for authenticated routes
- drop unused `Request` import

## Testing
- `npm test` *(fails: Failed to resolve import "../components/ErrorBoundary" in src/components/__tests__/ui-components.test.tsx)*
- `npm run lint` *(fails: many no-case-declarations errors and one no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f75b36348326aca5d2c20ab43963