### PR TITLE
refactor: use loggerService in request logger

### DIFF
--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
+import { loggerService } from '../services/logger.service';
 
 export const requestLogger = (
   req: Request,
@@ -14,7 +15,7 @@ export const requestLogger = (
     const duration = Date.now() - start;
     const { statusCode } = res;
 
-    console.log({
+    loggerService.info('Request log', {
       timestamp: new Date().toISOString(),
       method,
       path,
@@ -35,7 +36,7 @@ export const requestLogger = (
         ) VALUES ($1, $2, $3, $4, $5, $6, NOW())`,
         [method, path, statusCode, duration, ip, headers['user-agent']]
       ).catch(err => {
-        console.error('Error saving request log:', err);
+        loggerService.error('Error saving request log', { error: err });
       });
     }
   });


### PR DESCRIPTION
## Summary
- replace console log statements with loggerService
- log request logging errors via loggerService

## Testing
- `npm test` *(fails: Failed to resolve import "../components/ErrorBoundary" from "src/components/__tests__/ui-components.test.tsx")*


------
https://chatgpt.com/codex/tasks/task_e_68b0f761bb84832686c8a556289eb0e8