### PR TITLE
Load participants and presences for PresencaForm

### DIFF
--- a/src/components/oficinas/PresencaForm.tsx
+++ b/src/components/oficinas/PresencaForm.tsx
@@ -20,8 +20,9 @@ import { Button } from '../ui/button';
 import { Textarea } from '../ui/textarea';
 import { Checkbox } from '../ui/checkbox';
 import { ScrollArea } from '../ui/scroll-area';
-import { useRegistrarPresenca } from '@/hooks/useOficinas';
+import { useMarcarPresenca } from '@/hooks/useOficinas';
 import { Oficina } from '@/types/shared';
+import { format } from 'date-fns';
 
 const presencaSchema = z.object({
   beneficiaria_id: z.number(),
@@ -53,13 +54,13 @@ export function PresencaForm({
   beneficiarias,
   presencas = []
 }: PresencaFormProps) {
-  const { mutateAsync: registrarPresenca } = useRegistrarPresenca();
+  const { mutateAsync: registrarPresenca } = useMarcarPresenca(oficina.id);
 
   const handlePresencaChange = async (beneficiariaId: number, presente: boolean) => {
     try {
       await registrarPresenca({
-        oficinaId: oficina.id,
         beneficiariaId,
+        data: format(new Date(oficina.data_oficina), 'yyyy-MM-dd'),
         presente
       });
     } catch (error) {

--- a/src/pages/Oficinas.tsx
+++ b/src/pages/Oficinas.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import { useOficinas, useCreateOficina, useUpdateOficina, useDeleteOficina } from '@/hooks/useOficinas';
+import {
+  useOficinas,
+  useCreateOficina,
+  useUpdateOficina,
+  useDeleteOficina,
+  useOficinaParticipantes,
+  useOficinaPresencas
+} from '@/hooks/useOficinas';
 import { OficinaCard } from '@/components/oficinas/OficinaCard';
 import { OficinaModal } from '@/components/oficinas/OficinaModal';
 import { PresencaForm } from '@/components/oficinas/PresencaForm';
@@ -48,6 +55,14 @@ export default function OficinasPage() {
   const updateMutation = useUpdateOficina();
   const deleteMutation = useDeleteOficina();
   const { toast } = useToast();
+
+  const selectedOficinaId = presencaModal.oficina?.id;
+  const presencaData = presencaModal.oficina
+    ? format(new Date(presencaModal.oficina.data_oficina), 'yyyy-MM-dd')
+    : undefined;
+
+  const { data: participantes } = useOficinaParticipantes(selectedOficinaId ?? 0);
+  const { data: presencas } = useOficinaPresencas(selectedOficinaId ?? 0, presencaData);
 
   const oficinas = oficinasList?.data?.filter(oficina =>
     !filters.search ||
@@ -156,8 +171,10 @@ export default function OficinasPage() {
           open={presencaModal.open}
           onOpenChange={open => setPresencaModal({ open })}
           oficina={presencaModal.oficina}
-          beneficiarias={[]} // TODO: Passar lista de beneficiárias
-          presencas={[]} // TODO: Passar lista de presenças
+          beneficiarias={
+            participantes?.map(p => ({ id: p.id, nome: p.nome_completo })) || []
+          }
+          presencas={presencas || []}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- retrieve oficina participants and presences before showing the presence form
- update presence form to use `useMarcarPresenca` hook for registering attendance

## Testing
- `npm test` *(fails: Failed to resolve import "../components/ErrorBoundary" from test file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f7683cb8832686bb4c2d5f321950