### PR TITLE
feat: upload profile image to backend

### DIFF
--- a/src/components/EditarPerfil.tsx
+++ b/src/components/EditarPerfil.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '@/hooks/usePostgreSQLAuth';
 import { useToast } from '@/components/ui/use-toast';
+import apiService from '@/services/apiService';
 
 interface ProfileData {
   nome_completo: string;
@@ -106,23 +107,23 @@ export default function EditarPerfil() {
     setUploadingImage(true);
 
     try {
-      // Simular com URL local por enquanto
-      // TODO: Implementar upload para o servidor
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const imageUrl = e.target?.result as string;
+      const response = await apiService.uploadImage(file);
+
+      if (response.success && response.data) {
+        const imageUrl = `http://localhost:3000${response.data.url}`;
         setProfileData(prev => ({ ...prev, foto_url: imageUrl }));
         toast({
           title: "Sucesso",
-          description: "Imagem carregada com sucesso!"
+          description: "Imagem carregada com sucesso!",
         });
-      };
-      reader.readAsDataURL(file);
+      } else {
+        throw new Error(response.message || 'Erro no upload da imagem.');
+      }
     } catch (error) {
       toast({
         title: "Erro",
         description: "Não foi possível carregar a imagem.",
-        variant: "destructive"
+        variant: "destructive",
       });
     } finally {
       setUploadingImage(false);


### PR DESCRIPTION
## Summary
- send profile pictures to backend using apiService
- update user profile with backend image URL

## Testing
- `npm test` *(fails: Failed to resolve import "../components/ErrorBoundary" from "src/components/__tests__/ui-components.test.tsx")*
- `npm run lint` *(fails: 688 problems, 654 errors, 34 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f76a01208326ae8760d9fd82e4a4