### PR TITLE
Configure Playwright environment for Chromium E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,21 @@
+name: e2e
+on: [push, pull_request]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright (Chromium + deps)
+        run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - run: npx playwright test

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "e2e:browsers": "playwright install chromium",
+    "e2e:browsers:linux": "playwright install --with-deps chromium",
     "test:e2e:local": "bash scripts/run-e2e-local.sh",
     "test:e2e:ui": "playwright test --ui",
     "test:all": "npm run test && npm run test:e2e",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
-// Dedicated port for Playwright-managed preview server (avoid clashing with backend PORT)
-const WEB_PORT = process.env.PLAYWRIGHT_WEB_PORT || '4173';
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${WEB_PORT}`;
+const WEB_HOST = process.env.PLAYWRIGHT_WEB_HOST || '127.0.0.1';
+const WEB_PORT = Number(process.env.PLAYWRIGHT_WEB_PORT) || 5173;
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || `http://${WEB_HOST}:${WEB_PORT}`;
+const PREVIEW_COMMAND = `npm run preview -- --port=${WEB_PORT} --host=${WEB_HOST} --strictPort`;
 
 export default defineConfig({
   timeout: 90_000,
@@ -33,36 +34,12 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-    {
-      name: 'Mobile Chrome',
-      use: {
-        ...devices['Pixel 5'],
-        isMobile: true,
-      },
-    },
-    {
-      name: 'Mobile Safari',
-      use: {
-        ...devices['iPhone 12'],
-        isMobile: true,
-      },
-    },
   ],
 
-  // Let Playwright manage the frontend preview server on its own port
   webServer: {
-    // Force host/port and fail fast if port is taken
-    command: `npx vite preview --port ${WEB_PORT} --host 127.0.0.1 --strictPort`,
+    command: PREVIEW_COMMAND,
     url: BASE_URL,
-    reuseExistingServer: true,
-    timeout: 180000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
   },
 });

--- a/src/hooks/useCalendar.ts
+++ b/src/hooks/useCalendar.ts
@@ -10,7 +10,7 @@ import {
 
 const CALENDAR_CACHE_KEY = 'calendar';
 
-export default function useCalendar() {
+export function useCalendar() {
   const queryClient = useQueryClient();
 
   const getEvents = (filter: CalendarFilter) => {
@@ -112,3 +112,5 @@ export default function useCalendar() {
     markAttendance
   };
 }
+
+export default useCalendar;

--- a/src/hooks/useMaskedInput.ts
+++ b/src/hooks/useMaskedInput.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 
-export default function useMaskedInput(type: 'cpf' | 'telefone') {
+export function useMaskedInput(type: 'cpf' | 'telefone') {
   const [value, setValue] = useState('');
 
   const mask = useCallback((value: string) => {
@@ -74,3 +74,5 @@ export default function useMaskedInput(type: 'cpf' | 'telefone') {
     unmaskedValue
   };
 }
+
+export default useMaskedInput;

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -9,7 +9,7 @@ import type {
 } from '@/types/notification';
 
 // Hook para buscar notificações
-export default function useNotifications(filters?: {
+export function useNotifications(filters?: {
   read?: boolean;
   type?: string[];
   page?: number;
@@ -156,3 +156,5 @@ export function useSubscribeToPushNotifications() {
     },
   });
 }
+
+export default useNotifications;

--- a/src/services/oficinas.service.ts
+++ b/src/services/oficinas.service.ts
@@ -169,3 +169,7 @@ export const OficinasService = {
     return response.data;
   }
 };
+
+export const oficinasService = OficinasService;
+
+export default OficinasService;


### PR DESCRIPTION
## Summary
- add named exports for `useNotifications`, `useMaskedInput`, and `useCalendar` while preserving their default exports
- export an `oficinasService` alias from `oficinas.service.ts` to satisfy named imports
- configure the Playwright preview server, limit projects to Chromium, add helper scripts, and wire an e2e GitHub Action so browser installation is handled automatically

## Testing
- npm run build
- npm run test:e2e


------
https://chatgpt.com/codex/tasks/task_e_68c9b781ffe0832495c15f1610f984a0