### PR TITLE
chore: run full e2e suite in workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,21 +1,150 @@
 name: e2e
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: movemarias_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -h localhost -p 5432 -U postgres -d movemarias_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: movemarias_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+          cache: npm
+
+      - name: Install dependencies (root + backend)
+        run: |
+          npm ci
+          npm --prefix backend ci
+
+      - name: Prepare migration metadata tables
+        working-directory: backend
+        run: npm run premigrate:node
+
+      - name: Build backend
+        working-directory: backend
+        run: npm run build
+
+      - name: Apply migrations and seed data
+        working-directory: backend
+        env:
+          SUPERADMIN_EMAIL: bruno@move.com
+          SUPERADMIN_PASSWORD: 15002031
+          SUPERADMIN_NAME: "Bruno Administrador"
+          ADMIN_EMAIL: admin@example.com
+          ADMIN_PASSWORD: admin123
+          ADMIN_NAME: "Administrador"
+        run: |
+          npm run migrate:node
+          node scripts/seed-superadmin.js
+          node scripts/create-initial-data.js
+
+      - name: Start API server
+        working-directory: backend
+        env:
+          NODE_ENV: test
+          PORT: 3000
+          JWT_SECRET: test_secret
+          ENABLE_WS: true
+          REDIS_URL: redis://localhost:6379
+          CORS_ORIGIN: http://127.0.0.1:4173
+          SUPERADMIN_EMAIL: bruno@move.com
+          SUPERADMIN_PASSWORD: 15002031
+          SUPERADMIN_NAME: "Bruno Administrador"
+          ADMIN_EMAIL: admin@example.com
+          ADMIN_PASSWORD: admin123
+          ADMIN_NAME: "Administrador"
+        run: |
+          nohup npm start > ../api.log 2>&1 &
+          echo $! > ../api.pid
+          for i in {1..60}; do
+            curl -sf http://127.0.0.1:3000/api/health && break || sleep 2
+          done
+          curl -sf http://127.0.0.1:3000/api/health
+
+      - name: Prepare frontend build for E2E
+        run: |
+          cat > .env.e2e <<'ENV'
+          VITE_API_BASE_URL=http://127.0.0.1:3000/api
+          VITE_WS_URL=ws://127.0.0.1:3000
+          ENV
+          npm run build -- --mode e2e
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-      - name: Install Playwright (Chromium + deps)
+
+      - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
-      - run: npm run build
-      - run: npx playwright test
+
+      - name: Ensure preview port 4173 is free
+        run: (lsof -ti :4173 | xargs -r kill -9) || true
+
+      - name: Run E2E tests
+        env:
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:4173
+          PLAYWRIGHT_WEB_HOST: 127.0.0.1
+          PLAYWRIGHT_WEB_PORT: 4173
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          if-no-files-found: ignore
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/**/trace.zip
+          if-no-files-found: ignore
+
+      - name: Show API logs on failure
+        if: failure()
+        run: |
+          echo "===== backend api.log ====="
+          cat api.log || true
+
+      - name: Stop API server
+        if: always()
+        run: |
+          if [ -f api.pid ]; then
+            kill $(cat api.pid) || true
+            rm api.pid
+          fi


### PR DESCRIPTION
## Summary
- expand the dedicated e2e workflow to provision PostgreSQL and Redis services
- build and seed the backend before kicking off the Playwright suite
- prepare the frontend e2e build, reuse cached browsers, and upload diagnostics on failure

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68c9d01477808324b41cdfbade319603