### PR TITLE
Fix 033 migration function creation

### DIFF
--- a/backend/src/database/migrations/033_criar_organizacoes.sql
+++ b/backend/src/database/migrations/033_criar_organizacoes.sql
@@ -12,22 +12,16 @@ CREATE TABLE IF NOT EXISTS organizacoes (
   deleted_at TIMESTAMPTZ
 );
 
--- Trigger simples para updated_at
-DO $$
+-- Função para manter o updated_at atualizado
+CREATE OR REPLACE FUNCTION organizacoes_set_updated_at()
+RETURNS TRIGGER AS $BODY$
 BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_proc WHERE proname = 'organizacoes_set_updated_at'
-  ) THEN
-    CREATE FUNCTION organizacoes_set_updated_at()
-    RETURNS TRIGGER AS $$
-    BEGIN
-      NEW.updated_at = NOW();
-      RETURN NEW;
-    END;
-    $$ LANGUAGE plpgsql;
-  END IF;
-END $$;
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$BODY$ LANGUAGE plpgsql;
 
+-- Trigger simples para updated_at
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -38,4 +32,3 @@ BEGIN
     FOR EACH ROW EXECUTE FUNCTION organizacoes_set_updated_at();
   END IF;
 END $$;
-


### PR DESCRIPTION
## Summary
- define the organizacoes updated_at trigger function with CREATE OR REPLACE to avoid nested DO block quoting issues
- keep the trigger creation guard while ensuring the migration runs idempotently without syntax errors

## Testing
- not run (requires PostgreSQL service)


------
https://chatgpt.com/codex/tasks/task_e_68c9d8f9c21c8324bdc7d3c9495aae6a