### PR TITLE
fix: export auth response types for build

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -10,7 +10,7 @@ export interface TokenPayload {
   role: string;
 }
 
-interface User {
+export interface User {
   id: number;
   email: string;
   senha_hash: string;
@@ -23,7 +23,7 @@ interface User {
   data_atualizacao: Date;
 }
 
-interface AuthResponse {
+export interface AuthResponse {
   token: string;
   user: Partial<User>;
 }


### PR DESCRIPTION
## Summary
- export the authentication response and user interfaces from the auth service so downstream modules can reference them during type declaration generation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9dae34ba88324b2707f40adc96ef1