### PR TITLE
Fix E2E expectations for updated UI headings

### DIFF
--- a/tests/e2e/main.spec.ts
+++ b/tests/e2e/main.spec.ts
@@ -57,7 +57,7 @@ test.describe('Assist Move Assist - E2E Tests', () => {
 
   test('deve carregar página inicial', async ({ page }) => {
     await expect(page).toHaveTitle(/Assist Move/);
-    await expect(page.locator('h1')).toContainText('Assist Move');
+    await expect(page.getByRole('heading', { name: /Assist Move/i })).toBeVisible();
   });
 
   test('deve fazer login do super administrador', async ({ page }) => {
@@ -106,7 +106,7 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     await page.click('[data-testid="cadastrar-beneficiaria"]');
     
     // Verificar página de cadastro
-    await expect(page.locator('h1')).toContainText(/cadastrar beneficiária/i);
+    await expect(page.getByRole('heading', { name: /Nova Beneficiária/i })).toBeVisible();
     
     // Preencher formulário
     await page.fill('input[name="nome_completo"]', 'Maria da Silva Santos E2E');
@@ -143,8 +143,8 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     await page.click('button[type="submit"]');
     
     // Verificar mensagens de validação
-    await expect(page.locator('[data-testid="error-nome"]')).toContainText(/nome completo é obrigatório/i);
-    await expect(page.locator('[data-testid="error-cpf"]')).toContainText(/cpf é obrigatório/i);
+    await expect(page.locator('[data-testid="error-nome"]')).toContainText(/este campo é obrigatório/i);
+    await expect(page.locator('[data-testid="error-cpf"]')).toContainText(/este campo é obrigatório/i);
   });
 
   test('deve pesquisar beneficiárias', async ({ page }) => {
@@ -182,18 +182,18 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     
     // Testar navegação principal
     const menuItems = [
-      { selector: '[data-testid="menu-dashboard"]', expectedUrl: /.*dashboard/, expectedText: 'Dashboard' },
-      { selector: '[data-testid="menu-beneficiarias"]', expectedUrl: /.*beneficiarias/, expectedText: 'Beneficiárias' },
-      { selector: '[data-testid="menu-oficinas"]', expectedUrl: /.*oficinas/, expectedText: 'Oficinas' },
-      { selector: '[data-testid="menu-projetos"]', expectedUrl: /.*projetos/, expectedText: 'Projetos' },
-      { selector: '[data-testid="menu-feed"]', expectedUrl: /.*feed/, expectedText: 'Feed' },
-      { selector: '[data-testid="menu-relatorios"]', expectedUrl: /.*relatorios/, expectedText: 'Relatórios' }
+      { selector: '[data-testid="menu-dashboard"]', expectedUrl: /.*dashboard/, expectedHeading: /Dashboard/i },
+      { selector: '[data-testid="menu-beneficiarias"]', expectedUrl: /.*beneficiarias/, expectedHeading: /Beneficiárias/i },
+      { selector: '[data-testid="menu-oficinas"]', expectedUrl: /.*oficinas/, expectedHeading: /Oficinas/i },
+      { selector: '[data-testid="menu-projetos"]', expectedUrl: /.*projetos/, expectedHeading: /Projetos/i },
+      { selector: '[data-testid="menu-feed"]', expectedUrl: /.*feed/, expectedHeading: /Feed da Comunidade/i },
+      { selector: '[data-testid="menu-relatorios"]', expectedUrl: /.*relatorios/, expectedHeading: /Relatórios/i }
     ];
-    
+
     for (const item of menuItems) {
       await page.click(item.selector);
       await page.waitForURL(item.expectedUrl);
-      await expect(page.locator('h1')).toContainText(item.expectedText);
+      await expect(page.getByRole('heading', { name: item.expectedHeading })).toBeVisible();
     }
   });
 
@@ -213,9 +213,9 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     await page.click('[data-testid="user-menu"]');
     await page.click('[data-testid="logout-button"]');
     
-    // Verificar redirecionamento para login
-    await expect(page).toHaveURL(/.*auth/);
-    await expect(page.locator('[data-testid="login-form"]')).toBeVisible();
+    // Verificar que o CTA de login é exibido após o logout
+    await expect(page.getByRole('heading', { name: /Assist Move/i })).toBeVisible();
+    await expect(page.locator('[data-testid="login-button"]')).toBeVisible();
   });
 
   test('deve responder adequadamente em mobile', async ({ page, isMobile }) => {


### PR DESCRIPTION
## Summary
- update home and navigation heading assertions to use role-based locators with the current labels
- synchronize beneficiary form validation expectations with the actual error copy
- adjust the logout test to verify the login call-to-action now rendered by the protected route

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68c9e41a9c6483249c1fcb07cb720ec0