### PR TITLE
Add default credentials for development and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ npm run test:e2e:local # E2E completo com Docker local (scripts/run-e2e-local.sh
 
 ## Testes
 
+### Credenciais padrão
+
+As rotinas de seed garantem contas prontas para uso durante o desenvolvimento e
+execução dos testes (unitários, integração e E2E). Consulte
+[`docs/TEST_CREDENTIALS.md`](docs/TEST_CREDENTIALS.md) para ver a lista completa
+de usuários e senhas padrão.
+
 ### Unitários
 - Frontend: `npm run test:frontend`
 - Backend: `cd backend && npm test`

--- a/backend/scripts/create-initial-data.js
+++ b/backend/scripts/create-initial-data.js
@@ -26,10 +26,15 @@ async function createInitialUsers() {
     const ADMIN_NAME = process.env.ADMIN_NAME || 'Administrador';
     const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
     const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ChangeMe!123';
+    const E2E_NAME = process.env.E2E_TEST_NAME || 'E2E User';
+    const E2E_EMAIL = process.env.E2E_TEST_EMAIL || 'e2e@assist.local';
+    const E2E_PASSWORD = process.env.E2E_TEST_PASSWORD || 'e2e_password';
+    const E2E_ROLE = process.env.E2E_TEST_ROLE || 'admin';
 
     // Hash das senhas
     const brunoPasswordHash = await bcrypt.hash(SUPERADMIN_PASSWORD, 12);
     const adminPasswordHash = await bcrypt.hash(ADMIN_PASSWORD, 12);
+    const e2ePasswordHash = await bcrypt.hash(E2E_PASSWORD, 12);
 
     // Criar superadmin
     const upsertUser = `
@@ -61,6 +66,20 @@ async function createInitialUsers() {
     ]);
 
     console.log('✅ Admin criado:', adminResult.rows[0]);
+
+    const e2eResult = await pool.query(upsertUser, [
+      E2E_NAME,
+      E2E_EMAIL,
+      e2ePasswordHash,
+      E2E_ROLE
+    ]);
+
+    console.log('✅ Usuário E2E criado:', {
+      id: e2eResult.rows[0]?.id,
+      nome: e2eResult.rows[0]?.nome,
+      email: E2E_EMAIL,
+      papel: E2E_ROLE
+    });
 
     // Verificar se beneficiárias já existem
     await pool.query(`

--- a/docs/TEST_CREDENTIALS.md
+++ b/docs/TEST_CREDENTIALS.md
@@ -1,0 +1,24 @@
+# Credenciais de Desenvolvimento e Testes
+
+As rotinas de seed (`backend/scripts/create-initial-data.js`) garantem três usuários padrão
+que podem ser utilizados para desenvolvimento manual, testes automatizados e fluxos de
+homologação local.
+
+| Perfil | E-mail | Senha | Observações |
+| --- | --- | --- | --- |
+| Superadmin | `superadmin@example.com` | `ChangeMe!123` | Possui acesso total ao sistema. Valores podem ser sobrescritos via variáveis de ambiente `SUPERADMIN_*`. |
+| Admin | `admin@example.com` | `ChangeMe!123` | Perfil administrativo padrão para testes manuais. Pode ser configurado via variáveis `ADMIN_*`. |
+| Usuário E2E | `e2e@assist.local` | `e2e_password` | Conta utilizada pelos testes E2E/Playwright. O perfil padrão é `admin` e pode ser ajustado através das variáveis `E2E_TEST_*`. |
+
+## Como garantir as credenciais localmente
+
+```bash
+# Dentro do diretório backend
+cd backend
+npm install
+node scripts/create-initial-data.js
+```
+
+O script utiliza as credenciais de banco configuradas em `backend/.env` (ou variáveis de
+ambiente exportadas no shell) para inserir/atualizar os usuários. Execute-o após aplicar as
+migrações para garantir que os testes encontrem as contas necessárias.


### PR DESCRIPTION
## Summary
- ensure the seed script also provisions the Playwright/E2E user with configurable defaults
- document the default development/test accounts and reference the guide from the README

## Testing
- not run (docs and scripting changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cb329ee03083249661882eb4e46bf4