### PR TITLE
Fix dashboard stats test selectors

### DIFF
--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from "react";
+import { HTMLAttributes, ReactNode } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface StatCardProps {
+interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
   value: string | number;
   description?: string;
@@ -11,13 +11,14 @@ interface StatCardProps {
   className?: string;
 }
 
-const StatCard = ({ 
-  title, 
-  value, 
-  description, 
-  icon, 
+const StatCard = ({
+  title,
+  value,
+  description,
+  icon,
   variant = "default",
-  className 
+  className,
+  ...cardProps
 }: StatCardProps) => {
   const variantStyles = {
     default: "border-border",
@@ -27,7 +28,7 @@ const StatCard = ({
   };
 
   return (
-    <Card className={cn(
+    <Card {...cardProps} className={cn(
       "transition-smooth hover:shadow-soft",
       variantStyles[variant],
       className

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,13 +2,13 @@ import { Users, FileText, Calendar, TrendingUp, Heart, ClipboardCheck } from "lu
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { useEffect, useState } from "react";
+import { useEffect, useState, HTMLAttributes, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { apiService } from "@/services/apiService";
-import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 // Componente StatCard local
-interface StatCardProps {
+interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
   value: string | number;
   description?: string;
@@ -16,16 +16,24 @@ interface StatCardProps {
   variant?: "default" | "primary" | "success" | "warning";
 }
 
-const StatCard = ({ title, value, description, icon, variant = "default" }: StatCardProps) => {
+const StatCard = ({
+  title,
+  value,
+  description,
+  icon,
+  variant = "default",
+  className,
+  ...cardProps
+}: StatCardProps) => {
   const variantStyles = {
     default: "border-border",
     primary: "border-primary/20 bg-primary/10",
-    success: "border-green-200 bg-green-50", 
+    success: "border-green-200 bg-green-50",
     warning: "border-yellow-200 bg-yellow-50"
   };
 
   return (
-    <Card className={`${variantStyles[variant]}`}>
+    <Card className={cn(variantStyles[variant], className)} {...cardProps}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">
           {title}

--- a/tests/e2e/main.spec.ts
+++ b/tests/e2e/main.spec.ts
@@ -178,7 +178,7 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     // Testar navegação principal
     const menuItems = [
       { testId: 'menu-dashboard', expectedUrl: /.*#\/dashboard/, expectedHeading: /Dashboard/i },
-      { testId: 'menu-beneficiarias', expectedUrl: /.*#\/beneficiarias/, expectedHeading: /Beneficiárias/i },
+      { testId: 'menu-beneficiarias', expectedUrl: /.*#\/beneficiarias/, expectedHeading: 'Beneficiárias' },
       { testId: 'menu-oficinas', expectedUrl: /.*#\/oficinas/, expectedHeading: /Oficinas/i },
       { testId: 'menu-projetos', expectedUrl: /.*#\/projetos/, expectedHeading: /Projetos/i },
       { testId: 'menu-feed', expectedUrl: /.*#\/feed/, expectedHeading: /Feed da Comunidade/i },


### PR DESCRIPTION
## Summary
- allow dashboard StatCard component to forward HTML attributes so Playwright can find test ids
- adjust the Playwright menu navigation test to target the exact Beneficiárias heading and avoid strict mode collisions

## Testing
- npm run lint *(fails: existing lint violations in backend services unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb34aec0c48324bd14a48c3a3a4245