### PR TITLE
Streamline dashboard stat cards for reliable selectors

### DIFF
--- a/src/components/ui/stat-card.tsx
+++ b/src/components/ui/stat-card.tsx
@@ -1,23 +1,25 @@
-import { ReactNode } from "react";
+import { type ComponentPropsWithoutRef, type ReactNode } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-interface StatCardProps {
+type CardProps = ComponentPropsWithoutRef<typeof Card>;
+
+interface StatCardProps extends Omit<CardProps, "children"> {
   title: string;
   value: string | number;
   description?: string;
   icon?: ReactNode;
   variant?: "default" | "primary" | "success" | "warning";
-  className?: string;
 }
 
-const StatCard = ({ 
-  title, 
-  value, 
-  description, 
-  icon, 
+const StatCard = ({
+  title,
+  value,
+  description,
+  icon,
   variant = "default",
-  className 
+  className,
+  ...cardProps
 }: StatCardProps) => {
   const variantStyles = {
     default: "border-border",
@@ -27,7 +29,7 @@ const StatCard = ({
   };
 
   return (
-    <Card className={cn(
+    <Card {...cardProps} className={cn(
       "transition-smooth hover:shadow-soft",
       variantStyles[variant],
       className

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,45 +4,23 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import StatCard from "@/components/ui/stat-card";
 import { apiService } from "@/services/apiService";
-import { ReactNode } from "react";
 
-// Componente StatCard local
-interface StatCardProps {
-  title: string;
-  value: string | number;
-  description?: string;
-  icon?: ReactNode;
-  variant?: "default" | "primary" | "success" | "warning";
+interface DashboardActivity {
+  id: string | number;
+  type: string;
+  description: string;
+  time: string;
+  icon?: string;
 }
 
-const StatCard = ({ title, value, description, icon, variant = "default" }: StatCardProps) => {
-  const variantStyles = {
-    default: "border-border",
-    primary: "border-primary/20 bg-primary/10",
-    success: "border-green-200 bg-green-50", 
-    warning: "border-yellow-200 bg-yellow-50"
-  };
-
-  return (
-    <Card className={`${variantStyles[variant]}`}>
-      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">
-          {title}
-        </CardTitle>
-        {icon && <div>{icon}</div>}
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-bold">{value}</div>
-        {description && (
-          <p className="text-xs text-muted-foreground mt-1">
-            {description}
-          </p>
-        )}
-      </CardContent>
-    </Card>
-  );
-};
+interface DashboardTask {
+  id: string | number;
+  title: string;
+  due: string;
+  priority: "Alta" | "Média" | "Baixa" | string;
+}
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -54,8 +32,8 @@ export default function Dashboard() {
     atendimentosMes: 0,
     engajamento: "0%"
   });
-  const [recentActivities, setRecentActivities] = useState<any[]>([]);
-  const [upcomingTasks, setUpcomingTasks] = useState<any[]>([]);
+  const [recentActivities, setRecentActivities] = useState<DashboardActivity[]>([]);
+  const [upcomingTasks, setUpcomingTasks] = useState<DashboardTask[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -131,10 +109,6 @@ export default function Dashboard() {
           description={loading ? "Carregando..." : `${stats.beneficiariasAtivas} ativas • ${stats.beneficiariasInativas} inativas`}
           icon={<Users className="h-4 w-4" />}
           variant="primary"
-          // test ids
-          // container and count for E2E
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           data-testid="stats-beneficiarias"
         />
         {/* count element for tests */}
@@ -145,8 +119,6 @@ export default function Dashboard() {
           description={loading ? "Carregando..." : "Total preenchidos"}
           icon={<FileText className="h-4 w-4" />}
           variant="success"
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           data-testid="stats-usuarios"
         />
         <StatCard
@@ -155,8 +127,6 @@ export default function Dashboard() {
           description={loading ? "Carregando..." : "Este mês"}
           icon={<Calendar className="h-4 w-4" />}
           variant="warning"
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
           data-testid="stats-oficinas"
         />
         <StatCard

--- a/tests/e2e/main.spec.ts
+++ b/tests/e2e/main.spec.ts
@@ -178,7 +178,7 @@ test.describe('Assist Move Assist - E2E Tests', () => {
     // Testar navegação principal
     const menuItems = [
       { testId: 'menu-dashboard', expectedUrl: /.*#\/dashboard/, expectedHeading: /Dashboard/i },
-      { testId: 'menu-beneficiarias', expectedUrl: /.*#\/beneficiarias/, expectedHeading: /Beneficiárias/i },
+      { testId: 'menu-beneficiarias', expectedUrl: /.*#\/beneficiarias/, expectedHeading: 'Beneficiárias' },
       { testId: 'menu-oficinas', expectedUrl: /.*#\/oficinas/, expectedHeading: /Oficinas/i },
       { testId: 'menu-projetos', expectedUrl: /.*#\/projetos/, expectedHeading: /Projetos/i },
       { testId: 'menu-feed', expectedUrl: /.*#\/feed/, expectedHeading: /Feed da Comunidade/i },
@@ -193,7 +193,8 @@ test.describe('Assist Move Assist - E2E Tests', () => {
         link.click(),
       ]);
       if (item.expectedHeading) {
-        await expect(page.getByRole('heading', { name: item.expectedHeading })).toBeVisible();
+        const headingLocator = page.getByRole('heading', { name: item.expectedHeading });
+        await expect(headingLocator.first()).toBeVisible();
       }
     }
   });


### PR DESCRIPTION
## Summary
- update the shared StatCard component to inherit Card props while preserving variant styling and data attributes
- reuse the shared StatCard within the dashboard, add concrete activity/task typings, and remove ts-ignore directives from testing hooks
- scope the navigation test’s heading assertion to the first match to avoid strict-mode collisions when multiple headings contain the same text

## Testing
- npx eslint src/components/ui/stat-card.tsx src/pages/Dashboard.tsx tests/e2e/main.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb34aec0c48324bd14a48c3a3a4245