### PR TITLE
feat: add database wrapper with typed helpers

### DIFF
--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -1,0 +1,5 @@
+import { db as serviceDb } from '../services/db';
+
+export const db = serviceDb;
+
+export default db;

--- a/backend/src/jobs/NotificationJob.ts
+++ b/backend/src/jobs/NotificationJob.ts
@@ -5,6 +5,17 @@ import { WhatsAppService } from '../services/WhatsAppService';
 import { logger } from '../services/logger';
 import { db } from '../database';
 
+interface NotificationRecord {
+  id: string;
+  user_id: string;
+  canal: string[];
+  [key: string]: any;
+}
+
+interface NotificationPayload {
+  notificationId: string;
+}
+
 export class NotificationJob implements Job {
   constructor(
     private notificationService: NotificationService,
@@ -12,12 +23,12 @@ export class NotificationJob implements Job {
     private whatsAppService: WhatsAppService
   ) {}
 
-  async execute(payload: any): Promise<void> {
+  async execute(payload: NotificationPayload): Promise<void> {
     const { notificationId } = payload;
 
     try {
       // Buscar notificação
-      const notification = await db.one(
+      const notification = await db.one<NotificationRecord>(
         'SELECT * FROM notifications WHERE id = $1',
         [notificationId]
       );

--- a/backend/src/services/db.ts
+++ b/backend/src/services/db.ts
@@ -1,5 +1,7 @@
 import { db as client } from '../config/database';
 
+type QueryParams = any[] | undefined;
+
 interface BeneficiariaFilters {
   search?: string;
   status?: string;
@@ -7,67 +9,97 @@ interface BeneficiariaFilters {
   offset?: number;
 }
 
-const insert = async (table: string, data: Record<string, any>) => {
+const query = async <T = any>(text: string, params?: QueryParams): Promise<T[]> => {
+  const result = await client.query(text, params);
+  return (result ?? []) as T[];
+};
+
+const one = async <T = any>(text: string, params?: QueryParams): Promise<T> => {
+  const rows = await query<T>(text, params);
+  if (!rows.length) {
+    throw new Error('Query returned no results');
+  }
+  const [firstRow] = rows;
+  if (!firstRow) {
+    throw new Error('Query returned no results');
+  }
+  return firstRow;
+};
+
+const manyOrNone = async <T = any>(text: string, params?: QueryParams): Promise<T[]> => {
+  const rows = await query<T>(text, params);
+  return rows;
+};
+
+const none = async (text: string, params?: QueryParams): Promise<void> => {
+  await client.query(text, params);
+};
+
+const insert = async <T = any>(table: string, data: Record<string, any>): Promise<T> => {
   const keys = Object.keys(data);
   const values = Object.values(data);
   const placeholders = keys.map((_, idx) => `$${idx + 1}`).join(', ');
-  const query = `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders}) RETURNING *`;
-  const result = await client.query(query, values);
-  return result[0];
+  const statement = `INSERT INTO ${table} (${keys.join(', ')}) VALUES (${placeholders}) RETURNING *`;
+  const result = await query<T>(statement, values);
+  const [inserted] = result;
+  if (!inserted) {
+    throw new Error('Insert returned no results');
+  }
+  return inserted;
 };
 
-const update = async (table: string, id: string | number, data: Record<string, any>) => {
+const update = async <T = any>(table: string, id: string | number, data: Record<string, any>): Promise<T | null> => {
   const keys = Object.keys(data);
   if (keys.length === 0) {
-    return findById(table, id);
+    return findById<T>(table, id);
   }
   const values = Object.values(data);
   const setClause = keys.map((key, idx) => `${key} = $${idx + 1}`).join(', ');
-  const query = `UPDATE ${table} SET ${setClause} WHERE id = $${keys.length + 1} RETURNING *`;
-  const result = await client.query(query, [...values, id]);
-  return result[0];
+  const statement = `UPDATE ${table} SET ${setClause} WHERE id = $${keys.length + 1} RETURNING *`;
+  const result = await query<T>(statement, [...values, id]);
+  return result[0] ?? null;
 };
 
-const findById = async (table: string, id: string | number) => {
-  const result = await client.query(`SELECT * FROM ${table} WHERE id = $1`, [id]);
-  return result[0] || null;
+const findById = async <T = any>(table: string, id: string | number): Promise<T | null> => {
+  const result = await query<T>(`SELECT * FROM ${table} WHERE id = $1`, [id]);
+  return result[0] ?? null;
 };
 
 const getBeneficiarias = async (filters: BeneficiariaFilters) => {
-  let query = 'SELECT * FROM beneficiarias WHERE 1=1';
+  let queryText = 'SELECT * FROM beneficiarias WHERE 1=1';
   const params: any[] = [];
 
   if (filters.search) {
     params.push(`%${filters.search}%`);
-    query += ` AND (nome_completo ILIKE $${params.length} OR cpf ILIKE $${params.length})`;
+    queryText += ` AND (nome_completo ILIKE $${params.length} OR cpf ILIKE $${params.length})`;
   }
 
   if (filters.status) {
     params.push(filters.status);
-    query += ` AND status = $${params.length}`;
+    queryText += ` AND status = $${params.length}`;
   }
 
-  query += ' ORDER BY created_at DESC';
+  queryText += ' ORDER BY created_at DESC';
 
   if (filters.limit !== undefined) {
     params.push(filters.limit);
-    query += ` LIMIT $${params.length}`;
+    queryText += ` LIMIT $${params.length}`;
   }
 
   if (filters.offset !== undefined) {
     params.push(filters.offset);
-    query += ` OFFSET $${params.length}`;
+    queryText += ` OFFSET $${params.length}`;
   }
 
-  return client.query(query, params);
+  return query(queryText, params);
 };
 
 const getStats = async () => {
   const [totalBeneficiarias, activeBeneficiarias, totalFormularios, totalAtendimentos] = await Promise.all([
-    client.query('SELECT COUNT(*)::int AS total FROM beneficiarias WHERE deleted_at IS NULL'),
-    client.query("SELECT COUNT(*)::int AS total FROM beneficiarias WHERE status = 'ativa' AND deleted_at IS NULL"),
-    client.query('SELECT COUNT(*)::int AS total FROM formularios'),
-    client.query('SELECT COUNT(*)::int AS total FROM historico_atendimentos')
+    query('SELECT COUNT(*)::int AS total FROM beneficiarias WHERE deleted_at IS NULL'),
+    query("SELECT COUNT(*)::int AS total FROM beneficiarias WHERE status = 'ativa' AND deleted_at IS NULL"),
+    query('SELECT COUNT(*)::int AS total FROM formularios'),
+    query('SELECT COUNT(*)::int AS total FROM historico_atendimentos')
   ]);
 
   return {
@@ -80,10 +112,11 @@ const getStats = async () => {
   };
 };
 
-const query = client.query.bind(client);
-
 export const db = {
   query,
+  one,
+  none,
+  manyOrNone,
   insert,
   update,
   findById,


### PR DESCRIPTION
## Summary
- add a database index wrapper that re-exports the service db client
- extend the db helper with typed query/one/manyOrNone/none utilities
- update queue, report and notification services to use the typed helpers

## Testing
- npx tsc -p tsconfig.json *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c813a0883248a5b6abf7e627027