### PR TITLE
Normalize dashboard activity and task responses

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,7 +16,8 @@ export const api = {
   dashboard: {
     getRecentActivities: async (limit = 20): Promise<DashboardResponse> => {
       const res = await apiService.getDashboardActivities();
-      const activities = (res.success && Array.isArray(res.data)) ? (res.data as DashboardActivity[]) : [];
+      const normalized = res.success ? res.data ?? [] : [];
+      const activities = Array.isArray(normalized) ? normalized as DashboardActivity[] : [];
       return { activities: activities.slice(0, limit) };
     }
   }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -91,13 +91,13 @@ export default function Dashboard() {
       // Carregar atividades recentes reais
       const activitiesResponse = await apiService.getDashboardActivities();
       if (activitiesResponse.success) {
-        setRecentActivities(activitiesResponse.data);
+        setRecentActivities(Array.isArray(activitiesResponse.data) ? activitiesResponse.data : []);
       }
 
       // Carregar tarefas pendentes reais
       const tasksResponse = await apiService.getDashboardTasks();
       if (tasksResponse.success) {
-        setUpcomingTasks(tasksResponse.data);
+        setUpcomingTasks(Array.isArray(tasksResponse.data) ? tasksResponse.data : []);
       }
       
     } catch (error) {

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -251,11 +251,43 @@ class ApiService {
   }
 
   async getDashboardActivities(): Promise<ApiResponse<any[]>> {
-    return this.get('/dashboard/activities');
+    const response = await this.get<any>('/dashboard/activities');
+
+    if (!response.success) {
+      return response;
+    }
+
+    const payload = response.data;
+    const activities = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.activities)
+        ? payload.activities
+        : [];
+
+    return {
+      ...response,
+      data: activities
+    };
   }
 
   async getDashboardTasks(): Promise<ApiResponse<any[]>> {
-    return this.get('/dashboard/tasks');
+    const response = await this.get<any>('/dashboard/tasks');
+
+    if (!response.success) {
+      return response;
+    }
+
+    const payload = response.data;
+    const tasks = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.tasks)
+        ? payload.tasks
+        : [];
+
+    return {
+      ...response,
+      data: tasks
+    };
   }
 
   // Métodos específicos para projetos


### PR DESCRIPTION
## Summary
- normalize dashboard activity and task service methods to always expose plain arrays
- update dashboard page and API helper to guard against non-array payloads
- ensure components consume normalized data shapes for widgets and activities view

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68cd560c6c588324991595de29b97c3d