### PR TITLE
Add analytics stats for anamneses and declaracoes

### DIFF
--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -2,10 +2,18 @@ import React, { useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { apiService } from '@/services/apiService';
+import type { DashboardStatsResponse } from '@/types/dashboard';
+
+interface AnalyticsStats {
+  totalBeneficiarias: number;
+  activeBeneficiarias: number;
+  totalAnamneses: number;
+  totalDeclaracoes: number;
+}
 
 const Analytics = () => {
   const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState({
+  const [stats, setStats] = useState<AnalyticsStats>({
     totalBeneficiarias: 0,
     activeBeneficiarias: 0,
     totalAnamneses: 0,
@@ -19,7 +27,7 @@ const Analytics = () => {
         setLoading(true);
         const resp = await apiService.getDashboardStats();
         if (resp.success && resp.data) {
-          const data: any = resp.data;
+          const data = resp.data as DashboardStatsResponse;
           setStats({
             totalBeneficiarias: Number(data.totalBeneficiarias || 0),
             activeBeneficiarias: Number(data.activeBeneficiarias || 0),

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { useEffect, useState, HTMLAttributes, ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { apiService } from "@/services/apiService";
+import type { DashboardStatsResponse } from "@/types/dashboard";
 import { cn } from "@/lib/utils";
 
 // Componente StatCard local
@@ -76,8 +77,8 @@ export default function Dashboard() {
       
       // Carregar estatísticas reais do PostgreSQL
       const statsResponse = await apiService.getDashboardStats();
-      if (statsResponse.success) {
-        const data = statsResponse.data;
+      if (statsResponse.success && statsResponse.data) {
+        const data = statsResponse.data as DashboardStatsResponse;
         setStats({
           totalBeneficiarias: data.totalBeneficiarias || 0,
           beneficiariasAtivas: data.activeBeneficiarias || 0,

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -8,6 +8,7 @@ import type { Beneficiaria, BeneficiariaFiltros } from '../../backend/src/types/
 import type { Oficina } from '../../backend/src/types/oficina';
 import { translateErrorMessage } from '@/lib/apiError';
 import { API_URL } from '@/config';
+import type { DashboardStatsResponse } from '@/types/dashboard';
 const IS_DEV = (import.meta as any)?.env?.DEV === true || (import.meta as any)?.env?.MODE === 'development';
 
 function getCookie(name: string): string | null {
@@ -246,7 +247,7 @@ class ApiService {
   }
 
   // Dashboard methods
-  async getDashboardStats(): Promise<ApiResponse<any>> {
+  async getDashboardStats(): Promise<ApiResponse<DashboardStatsResponse>> {
     return this.get('/dashboard/stats');
   }
 

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,18 @@
+export interface DashboardStatsResponse {
+  totalBeneficiarias: number;
+  activeBeneficiarias: number;
+  inactiveBeneficiarias: number;
+  totalFormularios: number;
+  totalAtendimentos: number;
+  totalAnamneses: number;
+  totalDeclaracoes: number;
+  engajamento: number;
+  monthlyRegistrations?: Array<{
+    month: string;
+    count: number | string;
+  }>;
+  statusDistribution?: Array<{
+    status: string | null;
+    count: number | string;
+  }>;
+}


### PR DESCRIPTION
## Summary
- count anamneses from generic and dedicated tables plus declaracoes in the dashboard stats service
- expose the new totals through the API client with dedicated typing
- update analytics and dashboard pages to consume the typed stats response

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd560f28b0832495ca678458531b95