### PR TITLE
Improve typing for configuration flows and queues

### DIFF
--- a/backend/src/jobs/CleanupJob.ts
+++ b/backend/src/jobs/CleanupJob.ts
@@ -2,7 +2,7 @@ import { Job } from '../types/Job';
 import { db } from '../database';
 import { logger } from '../services/logger';
 
-interface CleanupJobPayload {
+export interface CleanupJobPayload {
   olderThanDays?: number;
   statuses?: string[];
 }

--- a/backend/src/jobs/NotificationJob.ts
+++ b/backend/src/jobs/NotificationJob.ts
@@ -20,7 +20,11 @@ interface NotificationRecord {
   payload?: Record<string, unknown> | null;
 }
 
-export class NotificationJob implements Job {
+export interface NotificationJobPayload {
+  notificationId: string;
+}
+
+export class NotificationJob implements Job<NotificationJobPayload> {
   private notificationService: NotificationService;
   private emailService: EmailService;
   private whatsAppService: WhatsAppService;
@@ -35,8 +39,13 @@ export class NotificationJob implements Job {
     this.whatsAppService = whatsAppService ?? new WhatsAppService();
   }
 
-  async execute(payload: any): Promise<void> {
+  async execute(payload: NotificationJobPayload): Promise<void> {
     const { notificationId } = payload;
+
+    if (!notificationId) {
+      logger.warn('Payload de notificação inválido recebido', { payload });
+      return;
+    }
 
     try {
       // Buscar notificação

--- a/backend/src/jobs/ReminderJob.ts
+++ b/backend/src/jobs/ReminderJob.ts
@@ -3,7 +3,7 @@ import { redis } from '../lib/redis';
 import { logger } from '../services/logger';
 import { db } from '../database';
 
-interface ReminderJobPayload {
+export interface ReminderJobPayload {
   reminderId: string;
   notificationId?: string;
   scheduledAt?: string | Date;

--- a/backend/src/jobs/ReportJob.ts
+++ b/backend/src/jobs/ReportJob.ts
@@ -3,7 +3,7 @@ import { logger } from '../services/logger';
 import { redis } from '../lib/redis';
 import { RelatorioService } from '../services/RelatorioService';
 
-interface ReportJobPayload {
+export interface ReportJobPayload {
   schedule?: string;
   options: {
     template: string;

--- a/backend/src/types/Job.ts
+++ b/backend/src/types/Job.ts
@@ -1,7 +1,9 @@
-export interface Job<TPayload = any> {
+export interface Job<TPayload = Record<string, unknown>> {
   execute(payload: TPayload): Promise<void>;
 }
 
-export type JobPayload<T extends Job<any>> = T extends Job<infer Payload>
+export type JobPayload<T extends Job<unknown>> = T extends Job<infer Payload>
   ? Payload
   : never;
+
+export type JobConstructor<TPayload> = new (...args: unknown[]) => Job<TPayload>;

--- a/backend/src/types/jobRegistry.ts
+++ b/backend/src/types/jobRegistry.ts
@@ -1,0 +1,13 @@
+import type { CleanupJobPayload } from '../jobs/CleanupJob';
+import type { NotificationJobPayload } from '../jobs/NotificationJob';
+import type { ReminderJobPayload } from '../jobs/ReminderJob';
+import type { ReportJobPayload } from '../jobs/ReportJob';
+
+export interface JobPayloadMap {
+  send_notification: NotificationJobPayload;
+  send_reminder: ReminderJobPayload;
+  generate_report: ReportJobPayload;
+  cleanup_data: CleanupJobPayload;
+}
+
+export type JobType = keyof JobPayloadMap;

--- a/backend/src/types/webhooks.ts
+++ b/backend/src/types/webhooks.ts
@@ -1,0 +1,23 @@
+export interface WebhookPayload {
+  event: string;
+  data: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface WebhookError {
+  message: string;
+  code?: string;
+  retryable?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface StoredWebhookEvent<TPayload = WebhookPayload> {
+  id: string;
+  endpoint: string;
+  event_type: string;
+  payload: TPayload;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  retry_count: number;
+  next_retry_at: Date | null;
+  error_message: string | null;
+}

--- a/src/hooks/usePostgreSQLAuth.tsx
+++ b/src/hooks/usePostgreSQLAuth.tsx
@@ -75,10 +75,10 @@ export const PostgreSQLAuthProvider: React.FC<AuthProviderProps> = ({ children }
             nome: userData.nome,
             email: userData.email,
             papel: userData.papel,
-            ativo: userData.ativo
+            ativo: userData.ativo ?? true
           };
-          
-          setUser(userData);
+
+          setUser(userProfile);
           setProfile(userProfile);
         } else {
           if (IS_DEV) console.log('Response inválido ou usuário não encontrado');
@@ -109,7 +109,6 @@ export const PostgreSQLAuthProvider: React.FC<AuthProviderProps> = ({ children }
 
       if (response && response.data && response.data.user) {
         const userData = response.data.user;
-        setUser(userData);
 
         if (response.data.token) {
           localStorage.setItem('token', response.data.token);
@@ -120,8 +119,9 @@ export const PostgreSQLAuthProvider: React.FC<AuthProviderProps> = ({ children }
           nome: userData.nome,
           email: userData.email,
           papel: userData.papel,
-          ativo: userData.ativo
+          ativo: userData.ativo ?? true
         };
+        setUser(userProfile);
         setProfile(userProfile);
 
         return { error: null };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,12 +1,18 @@
-export interface ApiResponse<T = unknown> {
-  data: T;
-  message?: string;
-  metadata?: Record<string, unknown>;
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
 }
 
-export interface RequestParams {
-  [key: string]: string | number | boolean | undefined;
+export interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  message?: string;
+  total?: number;
+  pagination?: Pagination;
 }
+
+export type RequestParams = Record<string, string | number | boolean | undefined>;
 
 export interface ApiService {
   get<T = unknown>(url: string, params?: RequestParams): Promise<ApiResponse<T>>;

--- a/src/types/configuracoes.ts
+++ b/src/types/configuracoes.ts
@@ -1,0 +1,53 @@
+import type { Pagination } from './api';
+
+export interface ConfiguracaoUsuario {
+  id: number;
+  email: string;
+  nome: string;
+  papel: string;
+  ativo: boolean;
+  avatar_url?: string | null;
+  cargo?: string | null;
+  departamento?: string | null;
+  bio?: string | null;
+  telefone?: string | null;
+  data_criacao?: string | null;
+  data_atualizacao?: string | null;
+}
+
+export interface PermissionSummary {
+  name: string;
+  description?: string | null;
+}
+
+export interface PaginatedCollection<TItem> {
+  data: TItem[];
+  pagination: Pagination;
+}
+
+export interface CreateUsuarioPayload {
+  email: string;
+  password: string;
+  nome: string;
+  papel?: string;
+  cargo?: string;
+  departamento?: string;
+  telefone?: string;
+}
+
+export interface UpdateUsuarioPayload {
+  nome?: string;
+  papel?: string;
+  ativo?: boolean;
+  cargo?: string;
+  departamento?: string;
+  bio?: string;
+  telefone?: string;
+  avatar_url?: string;
+}
+
+export type UsuarioPermissions = string[];
+
+export interface ResetPasswordPayload {
+  newPassword: string;
+}


### PR DESCRIPTION
## Summary
- replace the ad-hoc ApiResponse definition with shared API and configuration contract types and update apiService to return typed payloads for authentication and configuration endpoints
- refactor the configuration users/roles UI and PostgreSQL auth hook to consume the stronger types, avoiding implicit any usage when handling permissions and session data
- introduce typed payload registries for job and webhook queues, exporting payload interfaces from each job and improving error handling in QueueService and WebhookQueue

## Testing
- npm run type-check
- npm run lint *(fails: Cannot find package 'eslint-plugin-prettier' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cd79c92f388324ada74b967a0563c7