### PR TITLE
Handle empty oficina updates

### DIFF
--- a/backend/src/routes/__tests__/oficina.update-empty-body.test.ts
+++ b/backend/src/routes/__tests__/oficina.update-empty-body.test.ts
@@ -1,0 +1,40 @@
+import supertest from 'supertest';
+import express from 'express';
+import oficinasRoutes from '../oficina.routes';
+import { mockPool } from '../../setupTests';
+
+jest.mock('../../middleware/auth', () => ({
+  authenticateToken: (req: any, _res: any, next: any) => {
+    req.user = { id: '1', role: 'admin' };
+    next();
+  },
+  requireGestor: (_req: any, _res: any, next: any) => next(),
+  authorize: () => (_req: any, _res: any, next: any) => next()
+}));
+
+describe('PUT /api/oficinas/:id', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api/oficinas', oficinasRoutes);
+  });
+
+  it('retorna 400 quando nenhum campo é enviado para atualização', async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({
+      rows: [{ responsavel_id: 1 }],
+      rowCount: 1
+    });
+
+    const response = await supertest(app)
+      .put('/api/oficinas/1')
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toBe('Nenhum campo para atualizar');
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/routes/oficina.routes.ts
+++ b/backend/src/routes/oficina.routes.ts
@@ -234,6 +234,11 @@ router.put('/:id', authorize('oficinas.editar'), catchAsync(async (req, res): Pr
       return;
     }
 
+    if (error.message === "Nenhum campo para atualizar") {
+      res.status(400).json(errorResponse(error.message));
+      return;
+    }
+
     if (error.message === "Sem permissão para editar esta oficina") {
       res.status(403).json(errorResponse(error.message));
       return;

--- a/backend/src/services/oficina.service.ts
+++ b/backend/src/services/oficina.service.ts
@@ -280,9 +280,15 @@ export class OficinaService {
         }
       }
 
-      const fieldsToUpdate = Object.entries(validatedData)
+      const providedFields = Object.entries(data)
         .filter(([_, value]) => value !== undefined)
-        .map(([key, _]) => key);
+        .map(([key]) => key);
+
+      const fieldsToUpdate = providedFields.filter(field => validatedData[field as keyof UpdateOficinaDTO] !== undefined);
+
+      if (fieldsToUpdate.length === 0) {
+        throw new Error('Nenhum campo para atualizar');
+      }
 
       const setClauses = fieldsToUpdate.map((field, index) => `${field} = $${index + 1}`);
       const queryParams = fieldsToUpdate.map(field => validatedData[field as keyof UpdateOficinaDTO]);


### PR DESCRIPTION
## Summary
- prevent update queries when no oficina fields are provided and return a business error
- map the new empty-update error to HTTP 400 responses in the oficina route
- add an integration test ensuring PUT /api/oficinas/:id with an empty body does not trigger a 500 error

## Testing
- npm test -- --runTestsByPath src/routes/__tests__/oficina.update-empty-body.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cda075e47c83248805cb76d4efc59d