### PR TITLE
Expose pagination metadata for oficinas list

### DIFF
--- a/backend/src/routes/__tests__/oficina.routes.test.ts
+++ b/backend/src/routes/__tests__/oficina.routes.test.ts
@@ -2,6 +2,7 @@ import supertest from 'supertest';
 import express from 'express';
 import { Pool } from 'pg';
 import oficinasRoutes from '../oficina.routes';
+import { OficinaService } from '../../services/oficina.service';
 
 jest.mock('pg');
 jest.mock('ioredis');
@@ -27,6 +28,33 @@ describe('Oficinas Routes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('GET /oficinas - retorna dados com paginação', async () => {
+    const mockResult = {
+      data: [
+        {
+          id: 1,
+          nome: 'Oficina Teste',
+        },
+      ],
+      pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+    } as any;
+
+    const listarSpy = jest
+      .spyOn(OficinaService.prototype, 'listarOficinas')
+      .mockResolvedValue(mockResult);
+
+    const res = await supertest(app).get('/oficinas');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(mockResult);
+    expect(res.body.data.pagination).toEqual(
+      expect.objectContaining({ page: 1, limit: 50, total: 1, totalPages: 1 })
+    );
+
+    listarSpy.mockRestore();
   });
 
   it('GET /oficinas/horarios-disponiveis - requer data válida', async () => {

--- a/backend/src/routes/oficina.routes.ts
+++ b/backend/src/routes/oficina.routes.ts
@@ -27,7 +27,7 @@ router.get('/', authorize('oficinas.ler'), catchAsync(async (req, res): Promise<
     const result = await oficinaService.listarOficinas(filters) as any;
     
     res.json(successResponse(
-      result.data,
+      result,
       "Oficinas carregadas com sucesso"
     ));
     return;

--- a/src/hooks/__tests__/useOficinas.test.ts
+++ b/src/hooks/__tests__/useOficinas.test.ts
@@ -16,7 +16,11 @@ import useOficinas from '../useOficinas';
 import { createQueryClientWrapper } from './testUtils';
 
 beforeEach(() => {
-  vi.spyOn(OficinasService, 'listar').mockResolvedValue([] as any);
+  vi.spyOn(OficinasService, 'listar').mockResolvedValue({
+    success: true,
+    data: [],
+    pagination: { page: 1, limit: 50, total: 0, totalPages: 0 },
+  } as any);
 });
 
 afterEach(() => {

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -10,7 +10,7 @@ import type { AuthResponse, AuthenticatedSessionUser } from '../../backend/src/t
 import { translateErrorMessage } from '@/lib/apiError';
 import { API_URL } from '@/config';
 import type { DashboardStatsResponse } from '@/types/dashboard';
-import type { ApiResponse } from '@/types/api';
+import type { ApiResponse, Pagination } from '@/types/api';
 import type {
   ConfiguracaoUsuario,
   CreateUsuarioPayload,
@@ -216,20 +216,35 @@ class ApiService {
   }
 
   // Métodos específicos para oficinas
-  async getOficinas(params?: any): Promise<ApiResponse<any[]>> {
-  return this.get<Oficina[]>('/oficinas', { params });
+  async getOficinas(params?: any): Promise<ApiResponse<Oficina[]>> {
+    const response = await this.get<{ data: Oficina[]; pagination?: Pagination & { totalPages?: number } }>(
+      '/oficinas',
+      { params }
+    );
+
+    if (!response.success) {
+      return response as ApiResponse<Oficina[]>;
+    }
+
+    const payload = response.data;
+
+    return {
+      ...response,
+      data: payload?.data ?? [],
+      pagination: payload?.pagination,
+    };
   }
 
   async createOficina(data: any): Promise<ApiResponse<any>> {
-  return this.post<Oficina>('/oficinas', data);
+    return this.post<Oficina>('/oficinas', data);
   }
 
   async updateOficina(id: string, data: any): Promise<ApiResponse<any>> {
-  return this.put<Oficina>(`/oficinas/${id}`, data);
+    return this.put<Oficina>(`/oficinas/${id}`, data);
   }
 
   async deleteOficina(id: string): Promise<ApiResponse<any>> {
-  return this.delete<void>(`/oficinas/${id}`);
+    return this.delete<void>(`/oficinas/${id}`);
   }
 
   // Métodos específicos para beneficiárias

--- a/src/services/oficinas.service.ts
+++ b/src/services/oficinas.service.ts
@@ -1,4 +1,5 @@
 import { api } from './api';
+import type { ApiResponse, Pagination } from '@/types/api';
 
 export interface Oficina {
   id: number;
@@ -51,6 +52,11 @@ export interface AddParticipanteDTO {
   observacoes?: string;
 }
 
+interface ListOficinasPayload {
+  data: Oficina[];
+  pagination?: Pagination & { totalPages?: number };
+}
+
 export const OficinasService = {
   // Listar oficinas com filtros e paginação
   listar: async (params: ListOficinasParams = {}) => {
@@ -62,8 +68,24 @@ export const OficinasService = {
       }
     });
 
-    const response = await api.get(`/oficinas?${searchParams.toString()}`);
-    return response.data;
+    const response = await api.get<ApiResponse<ListOficinasPayload>>(`/oficinas?${searchParams.toString()}`);
+    const payload = response.data;
+
+    if (!payload) {
+      return { success: false, data: [] } as ApiResponse<Oficina[]>;
+    }
+
+    if (!payload.success) {
+      return payload as ApiResponse<Oficina[]>;
+    }
+
+    const listData = payload.data;
+
+    return {
+      ...payload,
+      data: listData?.data ?? [],
+      pagination: listData?.pagination,
+    } satisfies ApiResponse<Oficina[]>;
   },
 
   // Buscar oficina por ID

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -2,6 +2,7 @@ export interface Pagination {
   page: number;
   limit: number;
   total: number;
+  totalPages?: number;
 }
 
 export interface ApiResponse<T = unknown> {


### PR DESCRIPTION
## Summary
- include pagination metadata when responding to GET /oficinas
- normalize frontend services/hooks to consume the new payload shape
- cover the pagination metadata with a dedicated route test

## Testing
- npm run test:backend
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68cda07e6c5c83248a240532ce162219