### PR TITLE
Add unavailable participantes notice page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,9 @@ const EditarBeneficiaria = lazy(() => import("@/pages/EditarBeneficiaria"));
 const NotFound = lazy(() => import("@/pages/NotFound"));
 const Analytics = lazy(() => import("@/pages/Analytics"));
 const OficinasNew = lazy(() => import("@/pages/OficinasNew"));
-const ParticipantesProjeto = () => null as any; // módulo legado desativado
+const ParticipantesIndisponivel = lazy(
+  () => import("@/pages/ParticipantesIndisponivel")
+);
 const CalendarPage = lazy(() => import("@/pages/CalendarPage"));
 const Configuracoes = lazy(() => import("@/pages/Configuracoes"));
 const EditarPerfil = lazy(() => import("@/components/EditarPerfil"));
@@ -111,7 +113,10 @@ const App = () => (
                   {/* Demais páginas protegidas */}
                   <Route path="analytics" element={<Analytics />} />
                   <Route path="oficinas" element={<OficinasNew />} />
-                  <Route path="participantes" element={<ParticipantesProjeto />} />
+                  <Route
+                    path="participantes"
+                    element={<ParticipantesIndisponivel />}
+                  />
                   <Route path="configuracoes">
                     <Route index element={<Configuracoes />} />
                     <Route path="perfil" element={<EditarPerfil />} />

--- a/src/pages/ParticipantesIndisponivel.tsx
+++ b/src/pages/ParticipantesIndisponivel.tsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { AlertTriangle, ArrowLeft, UsersRound } from "lucide-react";
+
+const ParticipantesIndisponivel = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background px-4 py-8">
+      <Card className="max-w-2xl w-full shadow-lg border-border">
+        <CardHeader className="space-y-2 text-center">
+          <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <UsersRound className="h-8 w-8 text-primary" aria-hidden />
+          </div>
+          <CardTitle className="text-2xl font-semibold">
+            Área de participantes indisponível
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6 text-muted-foreground text-center">
+          <p>
+            A gestão de participantes está temporariamente desativada enquanto
+            migramos os dados para uma nova experiência. Durante esse período,
+            utilize os relatórios de beneficiárias ou fale com o suporte para
+            obter informações específicas.
+          </p>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+            <Button asChild>
+              <Link to="/dashboard">
+                <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+                Voltar ao painel
+              </Link>
+            </Button>
+            <Button variant="outline" asChild>
+              <a href="mailto:suporte@institutoelas.org.br">
+                <AlertTriangle className="mr-2 h-4 w-4" aria-hidden />
+                Falar com o suporte
+              </a>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ParticipantesIndisponivel;


### PR DESCRIPTION
## Summary
- replace the legacy `/participantes` stub in the router with a lazy-loaded page that gives users clear feedback about the module status
- add a dedicated `ParticipantesIndisponivel` page that explains the temporary unavailability and offers navigation back to the dashboard or to support

## Testing
- npm run lint *(fails: prettier check reports existing formatting issues in README.md)*
- npx eslint src/App.tsx src/pages/ParticipantesIndisponivel.tsx
- npx prettier --check src/App.tsx src/pages/ParticipantesIndisponivel.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d13cb12db88324bc1fa72e21d0c6a9