### PR TITLE
Coerce participation date fields

### DIFF
--- a/apps/backend/src/validators/participacao.validator.ts
+++ b/apps/backend/src/validators/participacao.validator.ts
@@ -13,14 +13,14 @@ export const participacaoSchema = z.object({
     'interesse',
     'inscrita'
   ]).default('inscrita'),
-  data_inscricao: z.date(),
-  data_conclusao: z.date().nullable().optional(),
+  data_inscricao: z.coerce.date(),
+  data_conclusao: z.coerce.date().nullable().optional(),
   observacoes: z.string().max(1000).nullable().optional(),
   certificado_emitido: z.boolean().default(false),
   presenca_percentual: z.number().min(0).max(100).default(0),
   ativo: z.boolean().default(true),
-  data_criacao: z.date(),
-  data_atualizacao: z.date()
+  data_criacao: z.coerce.date(),
+  data_atualizacao: z.coerce.date()
 });
 
 // Schema para criação de participação


### PR DESCRIPTION
## Summary
- coerce participation date fields so ISO date strings pass validation

## Testing
- `npm run test participacao` *(fails: frontend Vitest suite requires DOM APIs like document)*
- `npm run test:backend participacao` *(fails: jest command not available in backend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d239ebc08324b2e8f8aef6b7e499