### PR TITLE
feat: reuse beneficiaries search service in validation routes

### DIFF
--- a/apps/backend/src/__tests__/validation.controller.test.ts
+++ b/apps/backend/src/__tests__/validation.controller.test.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from 'express';
+import { ValidationController } from '../controllers/ValidationController';
+
+type SearchService = {
+  searchBeneficiarias: jest.Mock;
+};
+
+const redisMock = {
+  get: jest.fn(),
+  setex: jest.fn(),
+};
+
+jest.mock('../lib/redis', () => ({
+  __esModule: true,
+  redis: redisMock,
+  default: redisMock,
+}));
+
+describe('ValidationController - searchBeneficiarias', () => {
+  let controller: ValidationController;
+  let service: SearchService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = {
+      searchBeneficiarias: jest.fn(),
+    };
+    controller = new ValidationController(service as any);
+  });
+
+  it('should fetch from service and store the result in cache when not cached', async () => {
+    const req = { query: { query: 'Ana' } } as unknown as Request;
+    const json = jest.fn();
+    const res = { json } as unknown as Response;
+    const results = [{ id: 1, nome_completo: 'Ana Maria' }];
+
+    redisMock.get.mockResolvedValueOnce(null);
+    service.searchBeneficiarias.mockResolvedValueOnce(results);
+
+    await controller.searchBeneficiarias(req, res);
+
+    expect(service.searchBeneficiarias).toHaveBeenCalledWith('Ana');
+    expect(redisMock.setex).toHaveBeenCalledWith('search:Ana', 60, JSON.stringify(results));
+    expect(json).toHaveBeenCalledWith(results);
+  });
+
+  it('should return cached results without querying the service', async () => {
+    const req = { query: { query: 'Ana' } } as unknown as Request;
+    const json = jest.fn();
+    const res = { json } as unknown as Response;
+    const cached = [{ id: 2, nome_completo: 'Ana Clara' }];
+
+    redisMock.get.mockResolvedValueOnce(JSON.stringify(cached));
+
+    await controller.searchBeneficiarias(req, res);
+
+    expect(service.searchBeneficiarias).not.toHaveBeenCalled();
+    expect(redisMock.setex).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(cached);
+  });
+});

--- a/apps/backend/src/controllers/ValidationController.ts
+++ b/apps/backend/src/controllers/ValidationController.ts
@@ -3,9 +3,14 @@ import { redis } from '../lib/redis';
 import { validate_cpf } from '../utils/cpf-validator';
 import { logger } from '../services/logger';
 import { ValidationError } from '../utils';
+import { BeneficiariasService } from '../services/beneficiarias.service';
+import { pool } from '../config/database';
 
 export class ValidationController {
   private readonly CACHE_TTL = 60 * 5; // 5 minutos
+  constructor(
+    private readonly searchService: BeneficiariasService = new BeneficiariasService(pool, redis)
+  ) {}
 
   async validateCpf(req: Request, res: Response) {
     const { cpf } = req.body;

--- a/apps/backend/src/routes/api.ts
+++ b/apps/backend/src/routes/api.ts
@@ -17,6 +17,7 @@ import auditoriaRoutes from './auditoria.routes';
 
 // Rotas de beneficiárias
 import beneficiariasRoutes from './beneficiarias.routes';
+import validationRoutes from './validation.routes';
 
 // Rotas de configurações
 import configuracoesRoutes from './configuracoes.routes';
@@ -108,6 +109,7 @@ router.use('/auth', authRoutes);
 
 // 3. Rotas principais de negócio
 router.use('/beneficiarias', beneficiariasRoutes);
+router.use('/validation', validationRoutes);
 router.use('/projetos', projetosRoutes);
 router.use('/oficinas', oficinasRoutes);
 router.use('/participacoes', participacoesRoutes);

--- a/apps/backend/src/routes/validation.routes.ts
+++ b/apps/backend/src/routes/validation.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { ValidationController } from '../controllers/ValidationController';
+import { catchAsync } from '../middleware/errorHandler';
+import { BeneficiariasService } from '../services/beneficiarias.service';
+import { pool } from '../config/database';
+import { redis } from '../lib/redis';
+
+const router = Router();
+const beneficiariasService = new BeneficiariasService(pool, redis);
+const validationController = new ValidationController(beneficiariasService);
+
+router.post('/cpf', catchAsync((req, res, _next) => validationController.validateCpf(req, res)));
+router.post('/email', catchAsync((req, res, _next) => validationController.validateEmail(req, res)));
+router.post('/telefone', catchAsync((req, res, _next) => validationController.validateTelefone(req, res)));
+router.get('/beneficiarias', catchAsync((req, res, _next) => validationController.searchBeneficiarias(req, res)));
+
+export default router;


### PR DESCRIPTION
## Summary
- add a cached `searchBeneficiarias` helper to `BeneficiariasService`
- inject the shared beneficiaries search service into `ValidationController`
- expose consolidated validation routes and add a controller test covering cache usage

## Testing
- npm test validation.controller.test.ts *(fails: jest: not found in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d237665c8324af34882f10d045d6