### PR TITLE
Fix validation error handling and stabilize upload middleware types

### DIFF
--- a/apps/backend/src/__tests__/validation.controller.test.ts
+++ b/apps/backend/src/__tests__/validation.controller.test.ts
@@ -5,16 +5,25 @@ type SearchService = {
   searchBeneficiarias: jest.Mock;
 };
 
-const redisMock = {
-  get: jest.fn(),
-  setex: jest.fn(),
+type RedisMock = {
+  get: jest.Mock;
+  setex: jest.Mock;
 };
 
-jest.mock('../lib/redis', () => ({
-  __esModule: true,
-  redis: redisMock,
-  default: redisMock,
-}));
+jest.mock('../lib/redis', () => {
+  const redisMock: RedisMock = {
+    get: jest.fn(),
+    setex: jest.fn(),
+  };
+
+  return {
+    __esModule: true,
+    redis: redisMock,
+    default: redisMock,
+  };
+});
+
+const { redis: redisMock } = jest.requireMock('../lib/redis') as { redis: RedisMock };
 
 describe('ValidationController - searchBeneficiarias', () => {
   let controller: ValidationController;

--- a/apps/backend/src/controllers/ValidationController.ts
+++ b/apps/backend/src/controllers/ValidationController.ts
@@ -32,12 +32,13 @@ export class ValidationController {
 
       return res.json({ isValid });
 
-    } catch (error) {
-      logger.error('Erro ao validar CPF', { 
+    } catch (error: unknown) {
+      const message = this.getErrorMessage(error);
+      logger.error('Erro ao validar CPF', {
         cpf,
-        error: error.message
+        error: message
       });
-      
+
       throw new ValidationError('Erro ao validar CPF');
     }
   }
@@ -68,12 +69,13 @@ export class ValidationController {
         warnings: isDisposable ? ['Email temporário não permitido'] : []
       });
 
-    } catch (error) {
+    } catch (error: unknown) {
+      const message = this.getErrorMessage(error);
       logger.error('Erro ao validar email', {
         email,
-        error: error.message
+        error: message
       });
-      
+
       throw new ValidationError('Erro ao validar email');
     }
   }
@@ -114,12 +116,13 @@ export class ValidationController {
 
       return res.json({ isValid: true });
 
-    } catch (error) {
+    } catch (error: unknown) {
+      const message = this.getErrorMessage(error);
       logger.error('Erro ao validar telefone', {
         telefone,
-        error: error.message
+        error: message
       });
-      
+
       throw new ValidationError('Erro ao validar telefone');
     }
   }
@@ -148,13 +151,30 @@ export class ValidationController {
 
       return res.json(results);
 
-    } catch (error) {
+    } catch (error: unknown) {
+      const message = this.getErrorMessage(error);
       logger.error('Erro na busca de beneficiárias', {
         query,
-        error: error.message
+        error: message
       });
-      
+
       throw new ValidationError('Erro ao realizar busca');
+    }
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    try {
+      return JSON.stringify(error);
+    } catch (stringifyError) {
+      return 'Unknown error';
     }
   }
 }

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -1,7 +1,6 @@
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
-import { Request } from 'express';
 import { AppError } from '../utils';
 
 // Diretório único de uploads baseado no CWD do processo
@@ -12,10 +11,10 @@ if (!fs.existsSync(uploadDir)) {
 
 // Configuração do armazenamento
 const storage = multer.diskStorage({
-  destination: (req: Request, file: Express.Multer.File, cb: (error: Error | null, destination: string) => void) => {
+  destination: (req, file, cb) => {
     cb(null, uploadDir);
   },
-  filename: (req: Request, file: Express.Multer.File, cb: (error: Error | null, filename: string) => void) => {
+  filename: (req, file, cb) => {
     // Gerar nome único para o arquivo
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
     const ext = path.extname(file.originalname);
@@ -24,7 +23,7 @@ const storage = multer.diskStorage({
 });
 
 // Filtro de arquivos (somente imagens)
-const fileFilter = (req: Request, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+const fileFilter: NonNullable<multer.Options['fileFilter']> = (req, file, cb) => {
   // Permitir apenas imagens
   if (file.mimetype.startsWith('image/')) {
     cb(null, true);
@@ -63,7 +62,7 @@ const ALLOWED_DOC_MIME: readonly string[] = [
 
 const uploadAny = multer({
   storage,
-  fileFilter: (req: Request, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+  fileFilter: (req, file, cb) => {
     if (ALLOWED_DOC_MIME.includes(file.mimetype)) return cb(null, true);
     return cb(new AppError('Tipo de arquivo não permitido', 400));
   },

--- a/apps/backend/src/openapi/apiSpec.ts
+++ b/apps/backend/src/openapi/apiSpec.ts
@@ -1,6 +1,4 @@
-import { OpenAPIObject } from 'openapi3-ts/oas31';
-
-export const apiSpec: Partial<OpenAPIObject> = {
+export const apiSpec = {
   openapi: '3.1.0',
   info: {
     title: 'Assist Move API',

--- a/apps/backend/src/openapi/docs.ts
+++ b/apps/backend/src/openapi/docs.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import swaggerUi from 'swagger-ui-express';
 import { OpenAPIGenerator } from '@asteasolutions/zod-to-openapi';
 import { registry } from './routes';
-import { apiSpec } from './spec';
+import { apiSpec } from './apiSpec';
 
 const router = express.Router();
 

--- a/apps/backend/src/routes/documentos.routes.ts
+++ b/apps/backend/src/routes/documentos.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type RequestHandler } from 'express';
 import { loggerService } from '../services/logger';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { pool } from '../config/database';
@@ -30,7 +30,11 @@ router.get('/:beneficiariaId', authenticateToken, catchAsync(async (req, res) =>
 }));
 
 // POST /documentos/:beneficiariaId/upload - upload de documento
-router.post('/:beneficiariaId/upload', authenticateToken, uploadAnySingle('file'), catchAsync(async (req, res): Promise<void> => {
+const uploadFileMiddleware = (fieldName: string): RequestHandler => (
+  uploadAnySingle(fieldName) as unknown as RequestHandler
+);
+
+router.post('/:beneficiariaId/upload', authenticateToken, uploadFileMiddleware('file'), catchAsync(async (req, res): Promise<void> => {
   const authReq = req as AuthenticatedRequest & { file?: Express.Multer.File };
   try {
     const { beneficiariaId } = authReq.params as any;
@@ -70,7 +74,7 @@ router.post('/:beneficiariaId/upload', authenticateToken, uploadAnySingle('file'
 }));
 
 // PUT /documentos/:documentoId - nova versão
-router.put('/:documentoId', authenticateToken, uploadAnySingle('file'), catchAsync(async (req, res): Promise<void> => {
+router.put('/:documentoId', authenticateToken, uploadFileMiddleware('file'), catchAsync(async (req, res): Promise<void> => {
   const authReq = req as AuthenticatedRequest & { file?: Express.Multer.File };
   try {
     const { documentoId } = authReq.params as any;

--- a/apps/backend/src/routes/feed.routes.ts
+++ b/apps/backend/src/routes/feed.routes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, type RequestHandler } from 'express';
 import redis from '../lib/redis';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { successResponse, errorResponse } from '../utils/responseFormatter';
@@ -19,10 +19,14 @@ interface ExtendedRequest extends AuthenticatedRequest {
 }
 
 // Upload de imagem
+const uploadImageMiddleware = (fieldName: string): RequestHandler => (
+  uploadSingle(fieldName) as unknown as RequestHandler
+);
+
 router.post(
   '/upload-image',
   authenticateToken,
-  uploadSingle('image'),
+  uploadImageMiddleware('image'),
   catchAsync(async (req: ExtendedRequest, res: Response) => {
     try {
       if (!req.file) {

--- a/apps/backend/src/routes/upload.routes.ts
+++ b/apps/backend/src/routes/upload.routes.ts
@@ -1,4 +1,4 @@
-import { Router, Response } from 'express';
+import { Router, Response, type RequestHandler } from 'express';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { uploadAnySingle, UPLOAD_DIR } from '../middleware/upload';
 import path from 'path';
@@ -13,10 +13,14 @@ router.get('/test', (_req, res: Response) => {
 });
 
 // POST /upload - upload genérico de arquivo (imagens e PDFs)
+const uploadFileHandler = (fieldName: string): RequestHandler => (
+  uploadAnySingle(fieldName) as unknown as RequestHandler
+);
+
 router.post(
   '/',
   authenticateToken,
-  uploadAnySingle('file'),
+  uploadFileHandler('file'),
   async (req: AuthenticatedRequest & { file?: Express.Multer.File }, res: Response): Promise<void> => {
     try {
       if (!req.file) {

--- a/apps/backend/src/services/beneficiarias.service.ts
+++ b/apps/backend/src/services/beneficiarias.service.ts
@@ -29,7 +29,7 @@ interface Beneficiaria {
 interface BeneficiariaInput {
   nome_completo: string;
   cpf: string;
-  data_nascimento: string;
+  data_nascimento: Date;
   telefone: string;
   email?: string;
 }

--- a/apps/backend/src/utils/redisCache.ts
+++ b/apps/backend/src/utils/redisCache.ts
@@ -1,0 +1,33 @@
+import { logger } from '../services/logger';
+import { cacheService } from '../services/cache.service';
+
+export async function withCache<T>(
+  key: string,
+  resolver: () => Promise<T>,
+  ttl = 300
+): Promise<T> {
+  try {
+    const cached = await cacheService.get<T>(key);
+    if (cached !== null) {
+      return cached;
+    }
+  } catch (error) {
+    logger.warn('Falha ao recuperar cache', {
+      key,
+      error: error instanceof Error ? error.message : error
+    });
+  }
+
+  const result = await resolver();
+
+  try {
+    await cacheService.set(key, result, ttl);
+  } catch (error) {
+    logger.warn('Falha ao definir cache', {
+      key,
+      error: error instanceof Error ? error.message : error
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- add a helper to normalize unknown errors in ValidationController and adjust the related unit test mock
- introduce a reusable Redis caching utility, align BeneficiariasService typing, and relocate the OpenAPI spec to avoid Jest conflicts
- relax multer type annotations and wrap upload middleware usage so Express route typing no longer conflicts with duplicate type packages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6d6c30b348324bc091a7505793a25