### PR TITLE
Align migrate.sh priority ordering

### DIFF
--- a/apps/backend/scripts/migrate.sh
+++ b/apps/backend/scripts/migrate.sh
@@ -30,6 +30,35 @@ fi
 # Diretório das migrações
 MIGRATIONS_DIR="src/database/migrations"
 
+# Ordem prioritária (mantém compatibilidade com migrate-node.js)
+PRIORITY_ORDER=(
+  "001_criar_usuarios.sql"
+  "002_criar_beneficiarias.sql"
+  # projetos precisa existir antes de oficinas/participacoes
+  "005_criar_projetos.sql"
+  "003_criar_oficinas.sql"
+  "006_criar_participacoes.sql"
+)
+
+# Montar lista final de migrações: primeiro as prioritárias, depois o restante ordenado
+declare -a FILES_TO_RUN=()
+declare -A PRIORITY_SET=()
+
+mapfile -t ALL_MIGRATIONS < <(find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.sql' -printf '%f\n' | sort)
+
+for priority_file in "${PRIORITY_ORDER[@]}"; do
+  if [ -f "$MIGRATIONS_DIR/$priority_file" ]; then
+    FILES_TO_RUN+=("$priority_file")
+    PRIORITY_SET["$priority_file"]=1
+  fi
+done
+
+for file in "${ALL_MIGRATIONS[@]}"; do
+  if [ -z "${PRIORITY_SET[$file]}" ]; then
+    FILES_TO_RUN+=("$file")
+  fi
+done
+
 # Função para executar um arquivo SQL
 run_migration() {
   local file=$1
@@ -101,10 +130,9 @@ PGPASSWORD=$POSTGRES_PASSWORD psql \
     END $$;
   "
 
-# Executar todas as migrações em ordem alfabética
-for file in $(ls $MIGRATIONS_DIR/*.sql | sort); do
-  filename=$(basename "$file")
-  
+# Executar todas as migrações respeitando a ordem prioritária
+for filename in "${FILES_TO_RUN[@]}"; do
+
   # Verificar se a migração já foi aplicada
   already_applied=$(PGPASSWORD=$POSTGRES_PASSWORD psql \
     -h $POSTGRES_HOST \


### PR DESCRIPTION
## Summary
- add the same priority list used by migrate-node.js before iterating migrations
- build the final run list using prioritized migrations followed by the remaining sorted files
- execute migrations using the prioritized order to keep dependency expectations intact

## Testing
- ./scripts/migrate.sh *(fails: environment lacks psql and postgres connection)*

------
https://chatgpt.com/codex/tasks/task_e_68d8055034b08324bc84abbe8f70acd4