### PR TITLE
Permite matrícula apenas para projetos ativos

### DIFF
--- a/apps/backend/src/controllers/__tests__/matriculas.controller.test.ts
+++ b/apps/backend/src/controllers/__tests__/matriculas.controller.test.ts
@@ -1,0 +1,145 @@
+jest.mock('../../services/cache.service', () => ({
+  cacheService: {
+    delete: jest.fn().mockResolvedValue(undefined),
+    deletePattern: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+import { criarMatricula, verificarElegibilidade } from '../matriculas-fixed.controller';
+import { mockPool } from '../../setupTests';
+
+describe('MatriculasController - status do projeto', () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn()
+  };
+
+  const baseRequestBody = {
+    beneficiaria_id: 1,
+    projeto_id: 2,
+    motivacao_participacao: 'Motivação',
+    expectativas: 'Expectativas'
+  };
+
+  const createMockResponse = () => {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  beforeEach(() => {
+    mockClient.query.mockReset();
+    mockClient.release.mockReset();
+    (mockPool.connect as jest.Mock).mockReset();
+    (mockPool.query as jest.Mock).mockReset();
+    (mockPool.connect as jest.Mock).mockResolvedValue(mockClient);
+    mockClient.query.mockResolvedValue({ rows: [] });
+  });
+
+  describe('criarMatricula', () => {
+    it.each([
+      'planejamento',
+      'em_andamento',
+      'pausado'
+    ])('permite matrícula quando o projeto está em %s', async status => {
+      mockClient.query
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [{ id: baseRequestBody.beneficiaria_id }] })
+        .mockResolvedValueOnce({ rows: [{ id: baseRequestBody.projeto_id, status }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: 99, beneficiaria_id: 1, projeto_id: 2 }] })
+        .mockResolvedValue({});
+
+      const req: any = { body: baseRequestBody };
+      const res = createMockResponse();
+
+      await criarMatricula(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        message: 'Matrícula criada com sucesso'
+      }));
+    });
+
+    it.each([
+      'cancelado',
+      'concluido'
+    ])('bloqueia matrícula quando o projeto está %s', async status => {
+      mockClient.query
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rows: [{ id: baseRequestBody.beneficiaria_id }] })
+        .mockResolvedValueOnce({ rows: [{ id: baseRequestBody.projeto_id, status }] });
+
+      const req: any = { body: baseRequestBody };
+      const res = createMockResponse();
+
+      await criarMatricula(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'Projetos cancelados ou concluídos não aceitam novas matrículas'
+      });
+    });
+  });
+
+  describe('verificarElegibilidade', () => {
+    const createReq = () => ({
+      body: {
+        beneficiaria_id: 1,
+        projeto_id: 2
+      }
+    });
+
+    it.each([
+      'planejamento',
+      'em_andamento',
+      'pausado'
+    ])('considera elegível quando o status do projeto é %s', async status => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 2, status }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const req = createReq();
+      const res = { json: jest.fn() } as any;
+
+      await verificarElegibilidade(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          elegivel: true,
+          motivos: []
+        })
+      }));
+    });
+
+    it.each([
+      'cancelado',
+      'concluido'
+    ])('marca como não elegível quando o status do projeto é %s', async status => {
+      (mockPool.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 2, status }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const req = createReq();
+      const res = { json: jest.fn() } as any;
+
+      await verificarElegibilidade(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          elegivel: false,
+          motivos: expect.arrayContaining([
+            'Projetos cancelados ou concluídos não aceitam novas matrículas'
+          ])
+        })
+      }));
+    });
+  });
+});

--- a/apps/backend/src/controllers/matriculas-fixed.controller.ts
+++ b/apps/backend/src/controllers/matriculas-fixed.controller.ts
@@ -3,6 +3,12 @@ import pool from '../config/database';
 import redis from '../config/redis';
 import { cacheService } from '../services/cache.service';
 
+const INACTIVE_PROJECT_STATUSES = new Set(['cancelado', 'concluido']);
+const PROJECT_INACTIVE_ERROR_MESSAGE = 'Projetos cancelados ou concluídos não aceitam novas matrículas';
+
+const normalizeStatus = (status: unknown): string =>
+  typeof status === 'string' ? status.toLowerCase() : '';
+
 interface MatriculaData {
   beneficiaria_id: number;
   projeto_id: number;
@@ -178,11 +184,13 @@ export const criarMatricula = async (req: Request, res: Response): Promise<Respo
       });
     }
 
-    if (projetoCheck.rows[0].status !== 'ativo') {
+    const projetoStatus = normalizeStatus(projetoCheck.rows[0].status);
+
+    if (INACTIVE_PROJECT_STATUSES.has(projetoStatus)) {
       await client.query('ROLLBACK');
       return res.status(400).json({
         success: false,
-        error: 'Projeto não está ativo para novas matrículas'
+        error: PROJECT_INACTIVE_ERROR_MESSAGE
       });
     }
 
@@ -492,9 +500,9 @@ export const verificarElegibilidade = async (req: Request, res: Response): Promi
     };
 
     // Verificações básicas
-    if (projeto.rows[0].status !== 'ativo') {
+    if (INACTIVE_PROJECT_STATUSES.has(normalizeStatus(projeto.rows[0].status))) {
       resultado.elegivel = false;
-      resultado.motivos.push('Projeto não está ativo para novas matrículas');
+      resultado.motivos.push(PROJECT_INACTIVE_ERROR_MESSAGE);
     }
 
     if (matriculaExistente.rows.length > 0) {


### PR DESCRIPTION
## Summary
- atualiza os controladores de matrículas para permitir os novos status de projeto e bloquear apenas cancelados ou concluídos
- ajusta as mensagens de validação para refletir a nova regra de bloqueio
- adiciona testes de controlador cobrindo status permitidos e bloqueados

## Testing
- npm run test:backend *(fails: jest bin not found no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d8054a40c08324aa15b8ff99ad4fca