### PR TITLE
Ensure migrate script find command is POSIX-compatible

### DIFF
--- a/apps/backend/scripts/migrate.sh
+++ b/apps/backend/scripts/migrate.sh
@@ -44,7 +44,10 @@ PRIORITY_ORDER=(
 declare -a FILES_TO_RUN=()
 declare -A PRIORITY_SET=()
 
-mapfile -t ALL_MIGRATIONS < <(find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.sql' -printf '%f\n' | sort)
+ALL_MIGRATIONS=()
+while IFS= read -r migration_file; do
+  ALL_MIGRATIONS+=("$migration_file")
+done < <(find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.sql' -exec basename {} \; | sort)
 
 for priority_file in "${PRIORITY_ORDER[@]}"; do
   if [ -f "$MIGRATIONS_DIR/$priority_file" ]; then


### PR DESCRIPTION
## Summary
- replace the GNU-specific find/printf pipeline with a POSIX-friendly loop that collects sorted migration filenames via basename
- keep the existing priority ordering before appending the remaining migrations

## Testing
- PATH="$(pwd)/../../tmp/bin:$PATH" bash scripts/migrate.sh *(fails: missing bcryptjs while seeding, but migration script executed through the new POSIX-friendly find pipeline)*
- PATH="$(pwd)/../../tmp/bin:$PATH" bash scripts/migrate.sh *(busybox find to mimic BSD find; fails later for the same missing bcryptjs dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d80c04893c8324a8001e7965941711