### PR TITLE
Wrap frontend app with next-themes provider

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -8,24 +8,27 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Loading } from "@/components/ui/loading";
 import { AuthProvider } from "@/hooks/useAuth";
 import { AppRoutes } from "@/routes";
+import { ThemeProvider } from "next-themes";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <ErrorBoundary>
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Toaster />
-        <Sonner />
-        <AuthProvider>
-          <HashRouter>
-            <Suspense fallback={<Loading fullScreen message="Carregando aplicação..." />}>
-              <AppRoutes />
-            </Suspense>
-          </HashRouter>
-        </AuthProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <Toaster />
+          <Sonner />
+          <AuthProvider>
+            <HashRouter>
+              <Suspense fallback={<Loading fullScreen message="Carregando aplicação..." />}>
+                <AppRoutes />
+              </Suspense>
+            </HashRouter>
+          </AuthProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   </ErrorBoundary>
 );
 


### PR DESCRIPTION
## Summary
- import the next-themes ThemeProvider into the frontend app shell
- wrap the entire application (including Sonner) with the ThemeProvider so useTheme has context before rendering

## Testing
- `npm --prefix apps/frontend run lint` *(fails: Prettier reports existing formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d812683a848324bc6398967be875e0