### PR TITLE
Remove duplicate App default export

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -30,5 +30,3 @@ const App = () => (
 );
 
 export default App;
-
-export default App;


### PR DESCRIPTION
## Summary
- remove the duplicate default export from the App component in the frontend

## Testing
- npm run build (fails: missing apps/frontend/tsconfig.app.json)


------
https://chatgpt.com/codex/tasks/task_e_68d81266321c8324b7a438b04768ea5a