### PR TITLE
feat: add push subscription endpoint

### DIFF
--- a/apps/backend/src/__tests__/notifications.push-subscription.test.ts
+++ b/apps/backend/src/__tests__/notifications.push-subscription.test.ts
@@ -1,0 +1,86 @@
+import request from 'supertest';
+import express from 'express';
+
+jest.mock('../config/database', () => ({
+  pool: {
+    query: jest.fn()
+  }
+}));
+
+jest.mock('../middleware/auth', () => {
+  const actual = jest.requireActual('../middleware/auth');
+  return {
+    ...actual,
+    authenticateToken: jest.fn(async (req, _res, next) => {
+      req.user = {
+        id: '42',
+        email: 'user@example.com',
+        role: 'user',
+        permissions: []
+      } as any;
+      return next();
+    })
+  };
+});
+
+import notificationsRoutes from '../routes/notifications.routes';
+import { pool } from '../config/database';
+
+const app = express();
+app.use(express.json());
+app.use('/notifications', notificationsRoutes);
+
+const mockedPool = pool as unknown as { query: jest.Mock };
+
+describe('POST /notifications/push-subscription', () => {
+  const mockedQuery = mockedPool.query;
+
+  beforeEach(() => {
+    mockedQuery.mockReset();
+  });
+
+  it('persists the subscription and returns success response', async () => {
+    const subscriptionRow = {
+      id: 1,
+      user_id: 42,
+      endpoint: 'https://example.com/sub',
+      expiration_time: null,
+      p256dh: 'p256dh-value',
+      auth: 'auth-value',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString()
+    };
+
+    mockedQuery.mockResolvedValue({ rowCount: 1, rows: [subscriptionRow] });
+
+    const response = await request(app)
+      .post('/notifications/push-subscription')
+      .send({
+        endpoint: 'https://example.com/sub',
+        expirationTime: null,
+        keys: { p256dh: 'p256dh-value', auth: 'auth-value' }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    expect(mockedQuery.mock.calls[0][0]).toContain('INSERT INTO push_subscriptions');
+    expect(mockedQuery.mock.calls[0][1]).toEqual([
+      42,
+      'https://example.com/sub',
+      null,
+      'p256dh-value',
+      'auth-value'
+    ]);
+  });
+
+  it('returns 400 when payload is invalid', async () => {
+    const response = await request(app)
+      .post('/notifications/push-subscription')
+      .send({ keys: { p256dh: '', auth: '' } });
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(mockedQuery).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/database/migrations/047_criar_push_subscriptions.sql
+++ b/apps/backend/src/database/migrations/047_criar_push_subscriptions.sql
@@ -1,0 +1,15 @@
+-- Tabela para armazenar inscrições de notificações push dos usuários
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+  endpoint TEXT NOT NULL,
+  expiration_time TIMESTAMPTZ,
+  p256dh TEXT NOT NULL,
+  auth TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id),
+  UNIQUE(endpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user ON push_subscriptions(user_id);


### PR DESCRIPTION
## Summary
- add authenticated /notifications/push-subscription endpoint that validates payloads and upserts subscriptions
- create migration to persist push notification subscriptions per user
- cover subscription flow with request tests ensuring a 200 response and validation errors

## Testing
- npm run test:backend *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d847bb31b08324b7ca42fbf34273bc