### PR TITLE
Add authenticated notification delete endpoint

### DIFF
--- a/apps/backend/src/routes/__tests__/notifications.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/notifications.routes.test.ts
@@ -1,0 +1,110 @@
+import request from 'supertest';
+import express from 'express';
+
+process.env.NODE_ENV = 'test';
+process.env.PORT = '0';
+process.env.REDIS_DISABLED = 'true';
+
+const mockUser = {
+  id: '99',
+  role: 'admin',
+  email: 'admin@move.com'
+};
+
+const authenticateToken = jest.fn((req: any, _res: any, next: any) => {
+  req.user = mockUser;
+  next();
+});
+
+const passThroughMiddleware = jest.fn((_req: any, _res: any, next: any) => next());
+
+jest.mock('../../middleware/auth', () => ({
+  AuthService: {
+    login: jest.fn(),
+    getProfile: jest.fn(),
+    register: jest.fn(),
+    updateProfile: jest.fn(),
+    changePassword: jest.fn(),
+    generateToken: jest.fn(),
+    validateToken: jest.fn(),
+    verifyToken: jest.fn()
+  },
+  authenticateToken,
+  requireProfissional: passThroughMiddleware,
+  requireAdmin: passThroughMiddleware,
+  requireGestor: passThroughMiddleware,
+  requirePermissions: () => passThroughMiddleware,
+  requireRole: () => passThroughMiddleware,
+  authorize: () => passThroughMiddleware,
+  PERMISSIONS: {}
+}));
+
+jest.mock('../../config/database', () => {
+  const pool = { query: jest.fn() };
+  return {
+    __esModule: true,
+    pool,
+    default: pool
+  };
+});
+
+const { pool } = require('../../config/database');
+const poolQueryMock = pool.query as jest.Mock;
+
+const { apiRoutes } = require('../api');
+
+const app = express();
+app.use(express.json());
+app.use(apiRoutes);
+
+describe('Notifications routes - delete notification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authenticateToken.mockImplementation((req: any, _res: any, next: any) => {
+      req.user = mockUser;
+      next();
+    });
+  });
+
+  it('should delete a notification belonging to the authenticated user', async () => {
+    poolQueryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 55 }] });
+
+    const response = await request(app)
+      .delete('/notifications/55')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ success: true, data: { id: 55 } });
+    expect(poolQueryMock).toHaveBeenCalledWith(
+      'DELETE FROM notifications WHERE id = $1 AND user_id = $2 RETURNING id',
+      [55, Number(mockUser.id)]
+    );
+  });
+
+  it('should return 404 when notification does not exist for the user', async () => {
+    poolQueryMock.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+
+    const response = await request(app)
+      .delete('/notifications/123')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ success: false, error: 'Notificação não encontrada' });
+    expect(poolQueryMock).toHaveBeenCalledWith(
+      'DELETE FROM notifications WHERE id = $1 AND user_id = $2 RETURNING id',
+      [123, Number(mockUser.id)]
+    );
+  });
+
+  it('should prevent deletion when request is not authenticated', async () => {
+    authenticateToken.mockImplementationOnce((req: any, res: any) => {
+      res.status(401).json({ error: 'Token de acesso requerido' });
+    });
+
+    const response = await request(app)
+      .delete('/notifications/10');
+
+    expect(response.status).toBe(401);
+    expect(poolQueryMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/routes/notifications.routes.ts
+++ b/apps/backend/src/routes/notifications.routes.ts
@@ -76,6 +76,28 @@ router.patch('/:id', authenticateToken,
   }
 });
 
+// DELETE /notifications/:id
+router.delete('/:id', authenticateToken,
+  validateRequest(z.object({
+    params: z.object({ id: z.coerce.number() }),
+    body: z.any().optional(),
+    query: z.any().optional(),
+  })),
+  async (req: AuthenticatedRequest, res): Promise<void> => {
+  try {
+    const userId = Number(req.user!.id);
+    const { id } = req.params as any;
+    const notificationId = Number(id);
+    const result = await pool.query('DELETE FROM notifications WHERE id = $1 AND user_id = $2 RETURNING id', [notificationId, userId]);
+    if (result.rowCount === 0) { res.status(404).json(errorResponse('Notificação não encontrada')); return; }
+    res.json(successResponse({ id: result.rows[0].id }));
+    return;
+  } catch (error) {
+    res.status(500).json(errorResponse('Erro ao remover notificação'));
+    return;
+  }
+});
+
 // POST /notifications/mark-all-read
 router.post('/mark-all-read', authenticateToken, async (req: AuthenticatedRequest, res): Promise<void> => {
   try {

--- a/apps/frontend/src/pages/__tests__/NotificationsPage.test.tsx
+++ b/apps/frontend/src/pages/__tests__/NotificationsPage.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach, vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NotificationsPage from '../Notifications';
+import * as notificationsHooks from '@/hooks/useNotifications';
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: vi.fn(),
+  useMarkAllNotificationsAsRead: vi.fn(),
+  useDeleteNotification: vi.fn(),
+  useMarkNotificationAsRead: vi.fn(),
+}));
+
+describe('NotificationsPage', () => {
+  const deleteMutation = { mutate: vi.fn() };
+  const markAllMutation = { mutate: vi.fn(), isPending: false };
+  const markReadMutation = { mutate: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (notificationsHooks.useNotifications as unknown as Mock).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          title: 'Nova mensagem',
+          message: 'Você recebeu uma nova mensagem',
+          created_at: new Date().toISOString(),
+          read: false,
+        },
+      ],
+      isLoading: false,
+    });
+    (notificationsHooks.useMarkAllNotificationsAsRead as unknown as Mock).mockReturnValue(markAllMutation);
+    (notificationsHooks.useDeleteNotification as unknown as Mock).mockReturnValue(deleteMutation);
+    (notificationsHooks.useMarkNotificationAsRead as unknown as Mock).mockReturnValue(markReadMutation);
+  });
+
+  it('should render notifications list and allow removing an item', async () => {
+    const user = userEvent.setup();
+    render(<NotificationsPage />);
+
+    expect(screen.getByText('Nova mensagem')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /remover/i }));
+
+    expect(deleteMutation.mutate).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add authenticated DELETE /notifications/:id route that removes a user's notification with success and error handling
- create backend route tests covering successful deletion, not found, and unauthorized access cases
- add frontend NotificationsPage test ensuring the delete action triggers the mutation used by the UI

## Testing
- npm run test:backend
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d847b838c4832496dea7d7fc07cbd1