### PR TITLE
Add global configuration endpoints and client support

### DIFF
--- a/apps/backend/src/routes/__tests__/configuracoes.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/configuracoes.routes.test.ts
@@ -1,0 +1,112 @@
+import request from 'supertest';
+import express from 'express';
+
+process.env.NODE_ENV = 'test';
+process.env.PORT = '0';
+process.env.REDIS_DISABLED = 'true';
+
+const authenticateToken = jest.fn((req: any, _res: any, next: any) => {
+  req.user = { id: '1', role: 'admin', email: 'admin@move.com' };
+  next();
+});
+
+const authorizeMiddleware = jest.fn((_req: any, _res: any, next: any) => next());
+const authorize = jest.fn(() => authorizeMiddleware);
+
+jest.mock('../../middleware/auth', () => ({
+  authenticateToken,
+  authorize: (permission: string) => authorize(permission),
+}));
+
+const mockQuery = jest.fn();
+
+jest.mock('../../config/database', () => {
+  const pool = { query: mockQuery } as any;
+  return { pool, default: pool };
+});
+
+const { apiRoutes } = require('../api');
+
+const app = express();
+app.use(express.json());
+app.use(apiRoutes);
+
+describe('Configurações globais - rotas /configuracoes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve retornar configurações padrão quando não houver registros', async () => {
+    const defaultConfig = {
+      tema: 'sistema',
+      idioma: 'pt-BR',
+      fusoHorario: 'America/Sao_Paulo',
+      notificacoes: { habilitarEmails: true, habilitarPush: false },
+      organizacao: { nome: null, emailSuporte: null },
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // ensure table
+      .mockResolvedValueOnce({ rows: [] }) // select existing
+      .mockResolvedValueOnce({ rows: [{ payload: defaultConfig, updated_at: '2024-05-10T12:00:00.000Z' }] }); // insert default
+
+    const response = await request(app).get('/configuracoes');
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toEqual({
+      ...defaultConfig,
+      atualizadoEm: '2024-05-10T12:00:00.000Z',
+    });
+    expect(authorize).toHaveBeenCalledWith('users.manage');
+  });
+
+  it('deve atualizar parcialmente as configurações globais', async () => {
+    const existingConfig = {
+      tema: 'sistema',
+      idioma: 'pt-BR',
+      fusoHorario: 'America/Sao_Paulo',
+      notificacoes: { habilitarEmails: true, habilitarPush: false },
+      organizacao: { nome: null, emailSuporte: null },
+    };
+
+    const updatedConfig = {
+      ...existingConfig,
+      tema: 'escuro',
+      notificacoes: { habilitarEmails: false, habilitarPush: false },
+      organizacao: { nome: 'Move Marias', emailSuporte: 'contato@move.org' },
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] }) // ensure table
+      .mockResolvedValueOnce({ rows: [{ payload: existingConfig, updated_at: '2024-05-10T12:00:00.000Z' }] }) // load
+      .mockResolvedValueOnce({ rows: [{ payload: updatedConfig, updated_at: '2024-06-01T08:30:00.000Z' }] }); // persist
+
+    const response = await request(app)
+      .put('/configuracoes')
+      .send({
+        tema: 'ESCuro',
+        notificacoes: { habilitarEmails: false },
+        organizacao: { nome: 'Move Marias', emailSuporte: 'contato@move.org ' },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toEqual({
+      ...updatedConfig,
+      atualizadoEm: '2024-06-01T08:30:00.000Z',
+    });
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+  });
+
+  it('deve rejeitar payload vazio', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const response = await request(app).put('/configuracoes').send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error).toBe('Nenhuma configuração válida fornecida');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -12,12 +12,14 @@ import { API_URL } from '@/config';
 import type { DashboardStatsResponse } from '@/types/dashboard';
 import type { ApiResponse, Pagination } from '@/types/api';
 import type {
+  ConfiguracoesGlobais,
   ConfiguracaoUsuario,
   CreateUsuarioPayload,
   PaginatedCollection,
   PermissionSummary,
   ResetPasswordPayload,
   UpdateUsuarioPayload,
+  UpdateConfiguracoesPayload,
   UsuarioPermissions,
 } from '@/types/configuracoes';
 const IS_DEV = (import.meta as any)?.env?.DEV === true || (import.meta as any)?.env?.MODE === 'development';
@@ -189,7 +191,7 @@ class ApiService {
   }
 
   async put<T>(endpoint: string, data?: any): Promise<ApiResponse<T>> {
-    const response = await this.api.put(endpoint, data);
+    const response = await this.api.put<ApiResponse<T>>(endpoint, data);
     return response.data;
   }
 
@@ -505,12 +507,12 @@ class ApiService {
   }
 
   // Métodos específicos para configurações
-  async getConfiguracoes(): Promise<ApiResponse<any>> {
-    return this.get('/configuracoes');
+  async getConfiguracoes(): Promise<ApiResponse<ConfiguracoesGlobais>> {
+    return this.get<ConfiguracoesGlobais>('/configuracoes');
   }
 
-  async updateConfiguracoes(data: any): Promise<ApiResponse<any>> {
-    return this.put('/configuracoes', data);
+  async updateConfiguracoes(data: UpdateConfiguracoesPayload): Promise<ApiResponse<ConfiguracoesGlobais>> {
+    return this.put<ConfiguracoesGlobais>('/configuracoes', data);
   }
 
   // Configurações: usuários, papéis, permissões

--- a/apps/frontend/src/types/configuracoes.ts
+++ b/apps/frontend/src/types/configuracoes.ts
@@ -1,5 +1,27 @@
 import type { Pagination } from './api';
 
+export type TemaPreferido = 'claro' | 'escuro' | 'sistema';
+
+export interface ConfiguracoesGlobais {
+  tema: TemaPreferido;
+  idioma: string;
+  fusoHorario: string;
+  notificacoes: {
+    habilitarEmails: boolean;
+    habilitarPush: boolean;
+  };
+  organizacao: {
+    nome: string | null;
+    emailSuporte: string | null;
+  };
+  atualizadoEm: string | null;
+}
+
+export type UpdateConfiguracoesPayload = Partial<Omit<ConfiguracoesGlobais, 'atualizadoEm'>> & {
+  notificacoes?: Partial<ConfiguracoesGlobais['notificacoes']>;
+  organizacao?: Partial<ConfiguracoesGlobais['organizacao']>;
+};
+
 export interface ConfiguracaoUsuario {
   id: number;
   email: string;

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -125,6 +125,52 @@ Todas as rotas (exceto /auth/login) requerem autenticação via Bearer Token JWT
 - `GET /analytics/oficinas` - Estatísticas de oficinas
 - `GET /analytics/formularios` - Estatísticas de formulários
 
+### Configurações
+
+- `GET /configuracoes` - Recupera as preferências globais do sistema (tema, idioma, fuso horário, notificações padrão e dados da organização).
+- `PUT /configuracoes` - Atualiza parcialmente as preferências globais. Apenas campos enviados são alterados.
+
+#### Exemplo de payload (`PUT /configuracoes`)
+
+```json
+{
+  "tema": "escuro",
+  "idioma": "pt-BR",
+  "fusoHorario": "America/Sao_Paulo",
+  "notificacoes": {
+    "habilitarEmails": false,
+    "habilitarPush": true
+  },
+  "organizacao": {
+    "nome": "Move Marias",
+    "emailSuporte": "contato@move.org"
+  }
+}
+```
+
+#### Exemplo de resposta (`GET /configuracoes`)
+
+```json
+{
+  "success": true,
+  "message": "Operação realizada com sucesso",
+  "data": {
+    "tema": "escuro",
+    "idioma": "pt-BR",
+    "fusoHorario": "America/Sao_Paulo",
+    "notificacoes": {
+      "habilitarEmails": false,
+      "habilitarPush": true
+    },
+    "organizacao": {
+      "nome": "Move Marias",
+      "emailSuporte": "contato@move.org"
+    },
+    "atualizadoEm": "2024-06-01T08:30:00.000Z"
+  }
+}
+```
+
 ## Responses
 
 ### Sucesso


### PR DESCRIPTION
## Summary
- add persistence helpers and GET/PUT handlers for /configuracoes using the global settings payload
- cover defaults, partial updates, and validation with dedicated route tests
- align frontend types/services and API documentation with the new configuration contract

## Testing
- npm run test:backend *(fails: jest not found in workspace environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d847bc5db48324bd2289da938dff76