### PR TITLE
feat: add shared types package for frontend API service

### DIFF
--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -4,9 +4,13 @@
  */
 
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
-import type { Beneficiaria, BeneficiariaFiltros } from '../../../backend/src/types/beneficiarias';
-import type { Oficina } from '../../../backend/src/types/oficina';
-import type { AuthResponse, AuthenticatedSessionUser } from '../../../backend/src/types/auth';
+import type {
+  AuthResponse,
+  AuthenticatedSessionUser,
+  Beneficiaria,
+  BeneficiariaFiltros,
+  Oficina,
+} from '@assist/types';
 import { translateErrorMessage } from '@/lib/apiError';
 import { API_URL } from '@/config';
 import type { DashboardStatsResponse } from '@/types/dashboard';

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.app.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@assist/types": ["../../packages/types/src/index.ts"],
+      "@assist/types/*": ["../../packages/types/src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
+}

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -4,7 +4,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@assist/types": ["../../packages/types/src/index.ts"],
+      "@assist/types/*": ["../../packages/types/src/*"]
     },
     "noImplicitAny": true,
     "noUnusedParameters": true,

--- a/apps/frontend/tsconfig.node.json
+++ b/apps/frontend/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@assist/types": ["../../packages/types/src/index.ts"],
+      "@assist/types/*": ["../../packages/types/src/*"]
+    }
+  },
+  "include": ["vite.config.ts"],
+  "exclude": []
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -74,6 +74,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': resolve(__dirname, './src'),
+        '@assist/types': resolve(__dirname, '../../packages/types/src'),
       },
     },
     server: {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,24 @@
+export type UserRole = 'admin' | 'coordenador' | 'profissional' | 'assistente' | string;
+
+export interface JWTPayload {
+  id: number;
+  email?: string;
+  role: UserRole | string;
+  permissions?: string[];
+}
+
+export interface AuthenticatedSessionUser {
+  id: number;
+  email: string;
+  nome: string;
+  papel: string;
+  avatar_url?: string;
+  ultimo_login?: Date | string | null;
+  data_criacao?: Date | string;
+  data_atualizacao?: Date | string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: AuthenticatedSessionUser;
+}

--- a/packages/types/src/beneficiarias.ts
+++ b/packages/types/src/beneficiarias.ts
@@ -1,0 +1,92 @@
+export type BeneficiariaStatus = 'ativa' | 'inativa' | 'pendente' | 'desistente';
+
+export type TemporalValue = Date | string;
+
+export interface BeneficiariaFamiliar {
+  id?: number;
+  nome: string;
+  parentesco?: string | null;
+  data_nascimento?: TemporalValue | null;
+  trabalha?: boolean | null;
+  renda_mensal?: number | null;
+  observacoes?: string | null;
+}
+
+export interface Beneficiaria {
+  id: number;
+  codigo: string;
+  nome_completo: string;
+  cpf: string;
+  rg?: string | null;
+  rg_orgao_emissor?: string | null;
+  rg_data_emissao?: TemporalValue | null;
+  nis?: string | null;
+  data_nascimento: TemporalValue;
+  telefone: string;
+  telefone_secundario?: string | null;
+  email?: string | null;
+  endereco?: string | null;
+  bairro?: string | null;
+  cidade?: string | null;
+  estado?: string | null;
+  cep?: string | null;
+  referencia_endereco?: string | null;
+  escolaridade?: string | null;
+  estado_civil?: string | null;
+  num_dependentes?: number | null;
+  renda_familiar?: number | null;
+  situacao_moradia?: string | null;
+  observacoes_socioeconomicas?: string | null;
+  status: BeneficiariaStatus;
+  observacoes?: string | null;
+  historico_violencia?: string | null;
+  tipo_violencia?: string[] | null;
+  medida_protetiva?: boolean | null;
+  acompanhamento_juridico?: boolean | null;
+  acompanhamento_psicologico?: boolean | null;
+  created_at?: TemporalValue;
+  updated_at?: TemporalValue;
+  deleted_at?: TemporalValue | null;
+}
+
+export interface BeneficiariaDetalhada extends Beneficiaria {
+  familiares: BeneficiariaFamiliar[];
+  vulnerabilidades: string[];
+}
+
+export interface BeneficiariaFiltros {
+  search?: string;
+  status?: BeneficiariaStatus;
+  medida_protetiva?: boolean;
+  tipo_violencia?: string[];
+  data_inicio?: TemporalValue;
+  data_fim?: TemporalValue;
+}
+
+export interface BeneficiariaResumo {
+  id: number;
+  nome_completo: string;
+  cpf: string;
+  telefone?: string | null;
+  status: BeneficiariaStatus;
+  projetos_ativos: number;
+  oficinas_mes: number;
+  ultimo_formulario?: TemporalValue | null;
+}
+
+export interface BeneficiariaCreatePayload
+  extends Omit<
+    Beneficiaria,
+    | 'id'
+    | 'codigo'
+    | 'created_at'
+    | 'updated_at'
+    | 'deleted_at'
+    | 'tipo_violencia'
+  > {
+  vulnerabilidades?: string[];
+  familiares?: BeneficiariaFamiliar[];
+  tipo_violencia?: string[] | null;
+}
+
+export interface BeneficiariaUpdatePayload extends Partial<BeneficiariaCreatePayload> {}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,3 @@
+export * from './auth';
+export * from './beneficiarias';
+export * from './oficinas';

--- a/packages/types/src/oficinas.ts
+++ b/packages/types/src/oficinas.ts
@@ -1,0 +1,22 @@
+export type OficinaStatus = 'ativa' | 'inativa' | 'pausada' | 'concluida' | 'cancelada' | string;
+
+export interface Oficina {
+  id: number;
+  nome: string;
+  descricao?: string | null;
+  instrutor?: string | null;
+  data_inicio: string;
+  data_fim?: string | null;
+  horario_inicio: string;
+  horario_fim: string;
+  local?: string | null;
+  vagas_total: number;
+  vagas_ocupadas?: number;
+  status: OficinaStatus;
+  dias_semana?: string;
+  projeto_id?: number;
+  responsavel_id?: string | number;
+  ativo?: boolean;
+  data_criacao?: string;
+  data_atualizacao?: string;
+}


### PR DESCRIPTION
## Summary
- add a shared `@assist/types` module with beneficiary, workshop, and auth definitions
- point the frontend tsconfig and Vite resolver at the shared types alias
- update the API service and frontend tsconfig references to consume the shared module

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d84e5cf4588324b20e42a495cf4bfb