### PR TITLE
Use isAdmin flag for admin gating and add super admin test

### DIFF
--- a/apps/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.tsx
@@ -7,11 +7,11 @@ interface ProtectedRouteProps {
   adminOnly?: boolean;
 }
 
-export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ 
-  children, 
-  adminOnly = false 
+export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
+  children,
+  adminOnly = false
 }) => {
-  const { user, loading } = useAuth();
+  const { user, loading, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -19,7 +19,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     if (!loading) {
       if (user) {
         // Usuário autenticado: segue fluxo normal
-        if (adminOnly && user.papel !== 'admin') {
+        if (adminOnly && !isAdmin) {
           console.log('ProtectedRoute: Usuário sem privilégios de admin');
           navigate('/', { replace: true });
         }
@@ -28,7 +28,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         // Isso evita flakiness nos testes E2E no carregamento inicial.
       }
     }
-  }, [loading, user, adminOnly, navigate, location]);
+  }, [loading, user, adminOnly, navigate, location, isAdmin]);
 
   // Show loading state while checking authentication
   if (loading) {

--- a/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProtectedRoute } from '../ProtectedRoute';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  };
+});
+
+const mockUseAuth = vi.fn();
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth()
+}));
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockUseAuth.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('permite que usuários super_admin acessem rotas exclusivas de admin', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, nome: 'Super Admin', papel: 'super_admin' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: true
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute adminOnly>
+          <div>Área Administrativa</div>
+        </ProtectedRoute>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Área Administrativa')).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -84,16 +84,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const privilegedRoles = useMemo(
+    () => new Set(['admin', 'super_admin', 'superadmin']),
+    []
+  );
+
+  const isAdmin = !!(user?.papel && privilegedRoles.has(user.papel));
+
   return (
-    <AuthContext.Provider value={{ 
-      user, 
-      profile: user, // alias para compatibilidade
-      loading, 
-      signIn, 
-      signOut,
-      isAuthenticated: !!user,
-      isAdmin: user?.papel === 'admin' || user?.papel === 'super_admin' || user?.papel === 'superadmin'
-    }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        profile: user, // alias para compatibilidade
+        loading,
+        signIn,
+        signOut,
+        isAuthenticated: !!user,
+        isAdmin
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- update ProtectedRoute to gate admin-only routes using the isAdmin flag from the auth hook
- memoize privileged roles in the auth provider to keep isAdmin accurate for multiple admin roles
- add a unit test to ensure super_admin users can access admin-only routes

## Testing
- `cd apps/frontend && npx vitest run src/components/auth/__tests__/ProtectedRoute.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d84e5ff83483249f2614384fc7e92e