### PR TITLE
Add in-memory Redis hash support and notification test

### DIFF
--- a/apps/backend/src/websocket/__tests__/server.test.ts
+++ b/apps/backend/src/websocket/__tests__/server.test.ts
@@ -1,0 +1,36 @@
+jest.mock('socket.io', () => {
+  const mockServerInstance = {
+    use: jest.fn(),
+    on: jest.fn(),
+    emit: jest.fn(),
+    to: jest.fn().mockReturnThis()
+  };
+
+  const MockServer = jest.fn(() => mockServerInstance);
+
+  return {
+    Server: MockServer
+  };
+});
+
+import { WebSocketServer } from '../server';
+import { mockPool } from '../../setupTests';
+
+describe('WebSocketServer - markNotificationAsRead', () => {
+  beforeEach(() => {
+    const mockClient = {
+      query: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn()
+    };
+
+    (mockPool.connect as jest.Mock).mockResolvedValue(mockClient);
+  });
+
+  it('não lança exceção quando REDIS_DISABLED=true', async () => {
+    const server = new WebSocketServer({} as any, mockPool as any);
+
+    await expect(
+      (server as any).markNotificationAsRead('user-1', 'notification-1')
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add hash storage and hset support to the in-memory Redis stub used when REDIS_DISABLED=true
- allow Redis multi() stubs to record and execute chained hset calls
- cover markNotificationAsRead with a unit test to ensure no errors are thrown when Redis is disabled

## Testing
- npm test -- server.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d84e6247548324abe5db7c4dbd78c2