### PR TITLE
Add backend type-check script and fix config typing

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,8 @@
     "smoke:chat": "node scripts/smoke-chat.js",
     "smoke:chat:offline": "node scripts/smoke-chat-offline.js",
     "smoke:config": "node scripts/smoke-config.js",
-    "smoke:reports": "node scripts/smoke-reports.js"
+    "smoke:reports": "node scripts/smoke-reports.js",
+    "type-check": "tsc --noEmit -p tsconfig.build.json"
   },
   "dependencies": {
     "@types/exceljs": "^1.3.2",

--- a/apps/backend/src/routes/configuracoes.routes.ts
+++ b/apps/backend/src/routes/configuracoes.routes.ts
@@ -25,7 +25,10 @@ interface ConfiguracoesResposta extends ConfiguracoesPersistidas {
   atualizadoEm: string | null;
 }
 
-type AtualizacaoConfiguracoes = Partial<ConfiguracoesPersistidas> & {
+type AtualizacaoConfiguracoes = {
+  tema?: ConfiguracoesPersistidas['tema'];
+  idioma?: ConfiguracoesPersistidas['idioma'];
+  fusoHorario?: ConfiguracoesPersistidas['fusoHorario'];
   notificacoes?: Partial<ConfiguracoesPersistidas['notificacoes']>;
   organizacao?: Partial<ConfiguracoesPersistidas['organizacao']>;
 };


### PR DESCRIPTION
## Summary
- add a backend package script to run TypeScript in no-emit mode using the build configuration
- adjust configuration route update typing to allow partial nested properties for sanitization

## Testing
- npm --prefix apps/backend run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d84e6ce15c83249c08319b537f4fcc