### PR TITLE
Align Vitest alias resolution with Vite config

### DIFF
--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@assist/types': resolve(__dirname, '../../packages/types/src'),
+      '@assist/types/*': resolve(__dirname, '../../packages/types/src/*'),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@assist/types': path.resolve(__dirname, './packages/types/src'),
+      '@assist/types/*': path.resolve(__dirname, './packages/types/src/*'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- add the @assist/types alias mappings to the frontend Vitest configuration to mirror Vite
- extend the root Vitest configuration with the same aliases so repository-wide tests resolve shared types

## Testing
- npm --prefix apps/frontend run test

------
https://chatgpt.com/codex/tasks/task_e_68d85f70db788324910b6a70afafc980