### PR TITLE
Atualiza referências de usuários nas migrações de calendário e relatórios

### DIFF
--- a/apps/backend/prisma/migrations/20250827_add_calendar/migration.sql
+++ b/apps/backend/prisma/migrations/20250827_add_calendar/migration.sql
@@ -72,7 +72,7 @@ CREATE TABLE "CalendarNotification" (
 ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_organizer_id_fkey" FOREIGN KEY ("organizer_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_organizer_id_fkey" FOREIGN KEY ("organizer_id") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_recurrence_rule_id_fkey" FOREIGN KEY ("recurrence_rule_id") REFERENCES "RecurrenceRule"("id") ON DELETE SET NULL ON UPDATE CASCADE;
@@ -81,7 +81,7 @@ ALTER TABLE "CalendarEvent" ADD CONSTRAINT "CalendarEvent_recurrence_rule_id_fke
 ALTER TABLE "EventParticipant" ADD CONSTRAINT "EventParticipant_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "CalendarEvent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "EventParticipant" ADD CONSTRAINT "EventParticipant_participant_id_fkey" FOREIGN KEY ("participant_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "EventParticipant" ADD CONSTRAINT "EventParticipant_participant_id_fkey" FOREIGN KEY ("participant_id") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "CalendarNotification" ADD CONSTRAINT "CalendarNotification_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "CalendarEvent"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20250827_add_reports/migration.sql
+++ b/apps/backend/prisma/migrations/20250827_add_reports/migration.sql
@@ -41,13 +41,13 @@ CREATE TABLE "ReportExecution" (
 );
 
 -- AddForeignKey
-ALTER TABLE "ReportTemplate" ADD CONSTRAINT "ReportTemplate_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ReportTemplate" ADD CONSTRAINT "ReportTemplate_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "ReportTemplate" ADD CONSTRAINT "ReportTemplate_updated_by_id_fkey" FOREIGN KEY ("updated_by_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ReportTemplate" ADD CONSTRAINT "ReportTemplate_updated_by_id_fkey" FOREIGN KEY ("updated_by_id") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "ReportExecution" ADD CONSTRAINT "ReportExecution_template_id_fkey" FOREIGN KEY ("template_id") REFERENCES "ReportTemplate"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "ReportExecution" ADD CONSTRAINT "ReportExecution_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ReportExecution" ADD CONSTRAINT "ReportExecution_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- atualiza as migrações de relatórios e calendário para apontar as chaves estrangeiras de usuário para a tabela `usuarios`

## Testing
- DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma validate
- DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma migrate diff --from-migrations prisma/migrations --to-schema-datasource prisma/schema.prisma *(falha: Could not determine the connector from the migrations directory (missing migration_lock.toml))*

------
https://chatgpt.com/codex/tasks/task_e_68d85f6c69d0832497e9eb164e779e58