### PR TITLE
Enforce explicit CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,13 @@ assist-move-assist/
    POSTGRES_DB=assist_move_assist
    REDIS_HOST=127.0.0.1
    REDIS_PORT=6379
-   CORS_ORIGIN=http://localhost:5173
+  CORS_ORIGIN=http://localhost:5173
+  ```
+
+   > Para liberar múltiplos frontends informe uma lista separada por vírgulas, por exemplo:
+
+   ```env
+   CORS_ORIGIN=http://localhost:5173,http://localhost:4173
    ```
 
 3. Para ambientes diferentes, mantenha arquivos separados e utilize `ENV_FILE` ao iniciar a API (`ENV_FILE=.env.staging npm --prefix apps/backend run start`).

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -8,6 +8,7 @@ JWT_EXPIRY=24h
 # JWT_REFRESH_SECRET=sua-chave-secreta-refresh # opcional
 # AUTH_COOKIE_SAMESITE=lax # opcional (lax|strict|none)
 RATE_LIMIT_DISABLE=false
+# Aceita múltiplas origens separadas por vírgula (ex.: http://localhost:5173,http://localhost:4173)
 CORS_ORIGIN=http://localhost:5173
 
 # Banco de Dados

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -34,9 +34,26 @@ app.use(helmet());
 app.use(compression());
 
 // CORS
-const corsOrigin = env.CORS_ORIGIN || (env.NODE_ENV === 'development' ? '*' : '');
+const isProduction = env.NODE_ENV === 'production';
+const parsedCorsOrigins = env.CORS_ORIGIN
+  ?.split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+if (isProduction && (!parsedCorsOrigins || parsedCorsOrigins.length === 0)) {
+  throw new Error('CORS_ORIGIN deve ser definido em produção e conter pelo menos uma origem.');
+}
+
+const corsOriginOption = (() => {
+  if (parsedCorsOrigins && parsedCorsOrigins.length > 0) {
+    return parsedCorsOrigins.length === 1 && parsedCorsOrigins[0] === '*' ? true : parsedCorsOrigins;
+  }
+
+  return true;
+})();
+
 const corsOptions = {
-  origin: corsOrigin === '*' || corsOrigin === '' ? true : corsOrigin.split(',').map((o) => o.trim()),
+  origin: corsOriginOption,
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -1,6 +1,27 @@
 import path from 'path';
 import { env } from './env';
 
+const parseCorsOrigin = (originList?: string) => {
+  if (!originList) {
+    return undefined;
+  }
+
+  const parsedOrigins = originList
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  if (parsedOrigins.length === 0) {
+    return undefined;
+  }
+
+  if (parsedOrigins.length === 1 && parsedOrigins[0] === '*') {
+    return '*';
+  }
+
+  return parsedOrigins;
+};
+
 const config = {
   // Configurações do servidor
   server: {
@@ -56,7 +77,7 @@ const config = {
 
   // Configurações de cors
   cors: {
-    origin: env.CORS_ORIGIN || '*',
+    origin: parseCorsOrigin(env.CORS_ORIGIN),
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   },

--- a/docs/GUIA_EXECUCAO_DESENVOLVIMENTO.md
+++ b/docs/GUIA_EXECUCAO_DESENVOLVIMENTO.md
@@ -48,6 +48,8 @@ Os valores padrão suportam o ambiente local. Ajuste apenas se necessário. Prin
   - `REDIS_PORT=6379`
   - `CORS_ORIGIN=http://localhost:5173`
 
+  > Para permitir múltiplas origens informe uma lista separada por vírgulas (ex.: `CORS_ORIGIN=http://localhost:5173,http://localhost:4173`).
+
 ## 4. Subir Infraestrutura de Apoio
 
 Inicie Postgres e Redis via Docker Compose:


### PR DESCRIPTION
## Summary
- require explicit CORS origins in production and share parsing logic
- update backend configuration to parse comma-separated origins without wildcard fallback
- document how to configure multiple origins in sample env files and guides

## Testing
- npm --prefix apps/backend run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d862524bc08324a72ce2a173c6464e