### PR TITLE
Update React Query hooks for beneficiárias and participações

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useApi.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useApi.test.ts
@@ -1,8 +1,28 @@
-import { beforeEach, afterEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { beforeEach, afterEach, vi, describe, it, expect } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { apiService } from '@/services/apiService';
-import useApi from '../useApi';
-import { createQueryClientWrapper } from './testUtils';
+import useApi, { useBeneficiarias, useCreateParticipacao, useParticipacoes, useUpdateParticipacao } from '../useApi';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { wrapper, queryClient };
+};
 
 vi.mock('sonner', () => ({
   toast: {
@@ -11,20 +31,107 @@ vi.mock('sonner', () => ({
   },
 }));
 
-beforeEach(() => {
-  vi.spyOn(apiService, 'getBeneficiarias').mockResolvedValue({ success: true, data: [] });
-  vi.spyOn(apiService, 'createBeneficiaria').mockResolvedValue({ success: true, data: {} });
-  vi.spyOn(apiService, 'updateBeneficiaria').mockResolvedValue({ success: true, data: {} });
-});
+describe('useApi hooks', () => {
+  beforeEach(() => {
+    vi.spyOn(apiService, 'getBeneficiarias').mockResolvedValue({ success: true, data: [] });
+    vi.spyOn(apiService, 'createBeneficiaria').mockResolvedValue({ success: true, data: {} });
+    vi.spyOn(apiService, 'updateBeneficiaria').mockResolvedValue({ success: true, data: {} });
+  });
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-describe('useApi', () => {
-  it('deve inicializar sem erro', () => {
-    const wrapper = createQueryClientWrapper();
+  it('deve inicializar useApi sem erro', () => {
+    const { wrapper } = createWrapper();
     const { result } = renderHook(() => useApi(), { wrapper });
     expect(result.current).toBeDefined();
+  });
+
+  it('deve normalizar dados e paginação ao listar beneficiárias', async () => {
+    const pagination = { page: 2, limit: 20, total: 40, totalPages: 2 };
+    (apiService.getBeneficiarias as any).mockResolvedValueOnce({
+      success: true,
+      data: {
+        data: [{ id: 1 }],
+        pagination,
+      },
+    });
+
+    const params = { page: 2, limit: 20 };
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBeneficiarias(params), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(apiService.getBeneficiarias).toHaveBeenCalledWith(params);
+    expect(result.current.data).toEqual({ data: [{ id: 1 }], pagination });
+  });
+
+  it('deve retornar array de dados e sem paginação quando a resposta for simples', async () => {
+    (apiService.getBeneficiarias as any).mockResolvedValueOnce({
+      success: true,
+      data: [{ id: 1 }, { id: 2 }],
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBeneficiarias(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(apiService.getBeneficiarias).toHaveBeenCalledWith(undefined);
+    expect(result.current.data).toEqual({ data: [{ id: 1 }, { id: 2 }], pagination: undefined });
+  });
+
+  it('deve enviar o filtro correto ao buscar participações', async () => {
+    vi.spyOn(apiService, 'getParticipacoes').mockResolvedValue({ success: true, data: [] });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useParticipacoes('beneficiaria-1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(apiService.getParticipacoes).toHaveBeenCalledWith({ beneficiaria_id: 'beneficiaria-1' });
+  });
+
+  it('deve invalidar a lista de participações ao criar uma nova', async () => {
+    vi.spyOn(apiService, 'createParticipacao').mockResolvedValue({ success: true, data: {} });
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateParticipacao(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ beneficiaria_id: 'beneficiaria-2' });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['participacoes', { beneficiaria_id: 'beneficiaria-2' }],
+    });
+  });
+
+  it('deve invalidar a lista de participações ao atualizar um registro', async () => {
+    vi.spyOn(apiService, 'updateParticipacao').mockResolvedValue({ success: true, data: {} });
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateParticipacao(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: 'participacao-1',
+        data: { beneficiaria_id: 'beneficiaria-3' },
+      });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['participacoes', { beneficiaria_id: 'beneficiaria-3' }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- normalize the `useBeneficiarias` hook to forward query params and expose data plus pagination metadata
- align `useParticipacoes` query keys/params and ensure related mutations invalidate the scoped cache entry
- expand hook tests to cover pagination normalization, param forwarding, and mutation invalidations

## Testing
- npm run test:frontend -- --runInBand *(fails: `npm` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8624acaec8324acc4e0c2ced0fe11