### PR TITLE
Handle logout events across tabs

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useAuth.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useAuth.test.tsx
@@ -1,0 +1,43 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, beforeEach, expect } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { AuthProvider, useAuth } from '../useAuth';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+describe('useAuth - logout events', () => {
+  const mockUser = {
+    id: 1,
+    email: 'user@example.com',
+    nome: 'Test User',
+    papel: 'admin'
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should reset user and loading state when auth:logout event is dispatched', async () => {
+    localStorage.setItem('user', JSON.stringify(mockUser));
+
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.user).toEqual(mockUser);
+
+    act(() => {
+      window.dispatchEvent(new Event('auth:logout'));
+    });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.loading).toBe(false);
+
+    unmount();
+  });
+});

--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -49,6 +49,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setLoading(false);
   }, [authService]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleLogoutEvent = () => {
+      setUser(null);
+      setLoading(false);
+    };
+
+    const handleStorageEvent = (event: StorageEvent) => {
+      const relevantKeys = new Set(["token", "auth_token", "user"]);
+      if (event.key === null || relevantKeys.has(event.key)) {
+        handleLogoutEvent();
+      }
+    };
+
+    window.addEventListener("auth:logout", handleLogoutEvent);
+    window.addEventListener("storage", handleStorageEvent);
+
+    return () => {
+      window.removeEventListener("auth:logout", handleLogoutEvent);
+      window.removeEventListener("storage", handleStorageEvent);
+    };
+  }, []);
+
   const signIn = async (email: string, password: string): Promise<{ error?: Error }> => {
     try {
       setLoading(true);

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -114,6 +114,7 @@ class ApiService {
           localStorage.removeItem('user');
           // HashRouter-safe redirect
           if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('auth:logout'));
             window.location.hash = '#/auth';
           }
         }


### PR DESCRIPTION
## Summary
- dispatch a custom `auth:logout` event from the API 401 interceptor
- reset the auth context when logout or storage events fire and clean up listeners
- add a unit test ensuring the logout event clears the user state

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d8624d2e5c8324b6cda0cd4123fa66