### PR TITLE
Apply centralized backend security middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ assist-move-assist/
    CORS_ORIGIN=http://localhost:5173
    ```
 
+   > **Controles de segurança do backend**: durante testes ou execuções locais é possível desativar partes do bundle de segurança via variáveis de ambiente. Ajuste apenas o necessário para o cenário de teste.
+
+   ```env
+   RATE_LIMIT_DISABLE=true                 # ignora limites de requisições globais
+   SECURITY_SANITIZE_DISABLE=true          # desativa sanitização automática de body/query
+   SECURITY_CONTENT_TYPE_DISABLE=true      # permite POST/PUT sem Content-Type application/json
+   SECURITY_ORIGIN_DISABLE=true            # desabilita validação de origem em produção
+   SECURITY_REQUEST_LOG_DISABLE=true       # suprime logs adicionais de requisições sensíveis
+   ```
+
 3. Para ambientes diferentes, mantenha arquivos separados e utilize `ENV_FILE` ao iniciar a API (`ENV_FILE=.env.staging npm --prefix apps/backend run start`).
 
 ## Fluxos de Execução

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -8,6 +8,10 @@ JWT_EXPIRY=24h
 # JWT_REFRESH_SECRET=sua-chave-secreta-refresh # opcional
 # AUTH_COOKIE_SAMESITE=lax # opcional (lax|strict|none)
 RATE_LIMIT_DISABLE=false
+SECURITY_SANITIZE_DISABLE=false
+SECURITY_CONTENT_TYPE_DISABLE=false
+SECURITY_ORIGIN_DISABLE=false
+SECURITY_REQUEST_LOG_DISABLE=false
 CORS_ORIGIN=http://localhost:5173
 
 # Banco de Dados

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -29,7 +29,8 @@ const defaultsForTests = {
   POSTGRES_PORT: '5432',
   POSTGRES_DB: 'postgres',
   POSTGRES_USER: 'postgres',
-  POSTGRES_PASSWORD: 'postgres'
+  POSTGRES_PASSWORD: 'postgres',
+  SECURITY_REQUEST_LOG_DISABLE: 'true'
 } as const;
 
 const jwtExpirySchema = z
@@ -55,6 +56,10 @@ const envSchema = z.object({
   JWT_REFRESH_SECRET: z.string().optional(),
   AUTH_COOKIE_SAMESITE: z.enum(['lax', 'strict', 'none']).optional(),
   RATE_LIMIT_DISABLE: booleanFromEnv.default(false),
+  SECURITY_SANITIZE_DISABLE: booleanFromEnv.default(false),
+  SECURITY_CONTENT_TYPE_DISABLE: booleanFromEnv.default(false),
+  SECURITY_ORIGIN_DISABLE: booleanFromEnv.default(false),
+  SECURITY_REQUEST_LOG_DISABLE: booleanFromEnv.default(false),
   ENABLE_WS: booleanFromEnv.default(false),
   CORS_ORIGIN: z.string().optional(),
   POSTGRES_HOST: z.string().min(1, 'POSTGRES_HOST é obrigatório'),

--- a/apps/backend/tests/api.test.ts
+++ b/apps/backend/tests/api.test.ts
@@ -21,9 +21,29 @@ describe('API Tests', () => {
           email: 'bruno@move.com',
           password: '15002031'
         });
-      
+
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty('token');
+    });
+  });
+
+  describe('Security middleware', () => {
+    it('should include helmet security headers on /health', async () => {
+      const res = await request(app).get('/health');
+
+      expect(res.status).toBe(200);
+      expect(res.headers).toHaveProperty('x-dns-prefetch-control');
+      expect(res.headers).toHaveProperty('x-content-type-options', 'nosniff');
+    });
+
+    it('should reject payloads without application/json content type', async () => {
+      const res = await request(app)
+        .post('/api/auth/login')
+        .set('Content-Type', 'text/plain')
+        .send('email=invalid');
+
+      expect(res.status).toBe(415);
+      expect(res.body).toHaveProperty('error');
     });
   });
 


### PR DESCRIPTION
## Summary
- route the backend through the shared security setup and remove the duplicated helmet/CORS/rate-limit wiring from the app entry point
- expose environment flags for disabling individual security middlewares and document them for test scenarios
- extend the API test suite to assert the new security headers and the strict content-type enforcement

## Testing
- ⚠️ `npm --prefix apps/backend run type-check` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68d86238e7488324a551beb8f7270aa4