### PR TITLE
Refactor beneficiárias service layer and add cached summary endpoints

### DIFF
--- a/apps/backend/src/routes/__tests__/configuracoes.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/configuracoes.routes.test.ts
@@ -11,10 +11,16 @@ const authenticateToken = jest.fn((req: any, _res: any, next: any) => {
 });
 
 const authorizeMiddleware = jest.fn((_req: any, _res: any, next: any) => next());
-const authorize = jest.fn(() => authorizeMiddleware);
+const authorize = jest.fn((_permission?: string) => authorizeMiddleware);
+const requireProfissional = jest.fn((_req: any, _res: any, next: any) => next());
+const requireGestor = jest.fn((_req: any, _res: any, next: any) => next());
+const requireAdmin = jest.fn((_req: any, _res: any, next: any) => next());
 
 jest.mock('../../middleware/auth', () => ({
   authenticateToken,
+  requireProfissional,
+  requireGestor,
+  requireAdmin,
   authorize: (permission: string) => authorize(permission),
 }));
 
@@ -33,7 +39,12 @@ app.use(apiRoutes);
 
 describe('Configurações globais - rotas /configuracoes', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    mockQuery.mockReset();
+    authenticateToken.mockClear();
+    authorizeMiddleware.mockClear();
+    requireProfissional.mockClear();
+    requireGestor.mockClear();
+    requireAdmin.mockClear();
   });
 
   it('deve retornar configurações padrão quando não houver registros', async () => {

--- a/apps/backend/src/services/__tests__/beneficiarias.service.test.ts
+++ b/apps/backend/src/services/__tests__/beneficiarias.service.test.ts
@@ -1,0 +1,128 @@
+import { BeneficiariasService } from '../beneficiarias.service';
+import { cacheService } from '../cache.service';
+import { AppError } from '../../utils';
+
+jest.mock('../cache.service', () => {
+  const store = new Map<string, any>();
+  return {
+    cacheService: {
+      get: jest.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+      set: jest.fn(async (key: string, value: any) => {
+        store.set(key, value);
+      }),
+      deletePattern: jest.fn(async () => {
+        // noop
+      }),
+      __store: store,
+      __reset: () => store.clear()
+    }
+  };
+});
+
+const mockedCache = cacheService as unknown as typeof cacheService & { __reset: () => void };
+
+describe('BeneficiariasService', () => {
+  const baseResumo = {
+    beneficiaria: {
+      id: 1,
+      nome_completo: 'Maria',
+      status: 'ativa',
+      created_at: new Date('2024-01-01T00:00:00Z'),
+      updated_at: new Date('2024-01-02T00:00:00Z')
+    },
+    formularios: {
+      total: 3,
+      anamnese: 1,
+      ficha_evolucao: 1,
+      termos: 0,
+      visao_holistica: 1,
+      genericos: 0
+    },
+    atendimentos: {
+      total: 2,
+      ultimo_atendimento: new Date('2024-01-03T00:00:00Z')
+    },
+    participacoes: {
+      total_ativas: 1
+    }
+  };
+
+  let repository: any;
+  let service: BeneficiariasService;
+
+  beforeEach(() => {
+    mockedCache.__reset();
+    repository = {
+      buscarPorTexto: jest.fn(),
+      listarAtivas: jest.fn().mockResolvedValue({ data: [], total: 0, pages: 0 }),
+      findWithRelations: jest.fn(),
+      getResumo: jest.fn().mockResolvedValue(baseResumo),
+      getAtividades: jest.fn().mockResolvedValue({
+        data: [
+          {
+            type: 'formulario',
+            id: 10,
+            created_at: new Date('2024-01-04T00:00:00Z'),
+            created_by: 1,
+            created_by_name: null
+          }
+        ],
+        pagination: { page: 1, limit: 20, total: 1 }
+      }),
+      findByCPF: jest.fn().mockResolvedValue(null),
+      createWithRelations: jest.fn().mockResolvedValue({ id: 99 }),
+      findById: jest.fn().mockResolvedValue({ id: 99, cpf: '12345678900' }),
+      updateWithRelations: jest.fn().mockResolvedValue({ id: 99 }),
+      softDelete: jest.fn().mockResolvedValue(undefined),
+      buscarPorId: jest.fn().mockResolvedValue({ id: 1 })
+    };
+    service = new BeneficiariasService({} as any, undefined, repository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deve buscar resumo e armazenar em cache', async () => {
+    const resumo1 = await service.getResumo(1);
+    const resumo2 = await service.getResumo(1);
+
+    expect(resumo1).toEqual(baseResumo);
+    expect(resumo2).toEqual(baseResumo);
+    expect(repository.getResumo).toHaveBeenCalledTimes(1);
+  });
+
+  it('deve retornar atividades paginadas com cache', async () => {
+    const atividades = await service.getAtividades(1, 1, 20);
+
+    expect(atividades.pagination.total).toBe(1);
+    expect(repository.getAtividades).toHaveBeenCalledWith(1, 1, 20);
+  });
+
+  it('deve invalidar cache ao criar beneficiária', async () => {
+    await service.createBeneficiaria({ nome_completo: 'Teste' } as any, { skipValidation: true });
+
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:list:*');
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:99:*');
+  });
+
+  it('deve invalidar cache ao atualizar beneficiária', async () => {
+    await service.updateBeneficiaria(99, { nome_completo: 'Atualizada' } as any, { skipValidation: true });
+
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:list:*');
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:99:*');
+  });
+
+  it('deve invalidar cache ao excluir beneficiária', async () => {
+    await service.deleteBeneficiaria(5);
+
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:list:*');
+    expect(cacheService.deletePattern).toHaveBeenCalledWith('beneficiarias:5:*');
+  });
+
+  it('deve lançar AppError quando resumo não encontrado', async () => {
+    repository.getResumo.mockResolvedValueOnce(null);
+
+    await expect(service.getResumo(999)).rejects.toBeInstanceOf(AppError);
+  });
+});

--- a/apps/backend/src/types/beneficiarias.ts
+++ b/apps/backend/src/types/beneficiarias.ts
@@ -81,3 +81,52 @@ export interface BeneficiariaCreatePayload
 
 export interface BeneficiariaUpdatePayload
   extends Partial<BeneficiariaCreatePayload> {}
+
+export interface BeneficiariaResumoDetalhado {
+  beneficiaria: {
+    id: number;
+    nome_completo: string;
+    status: BeneficiariaStatus;
+    created_at: Date;
+    updated_at: Date;
+  };
+  formularios: {
+    total: number;
+    anamnese: number;
+    ficha_evolucao: number;
+    termos: number;
+    visao_holistica: number;
+    genericos: number;
+  };
+  atendimentos: {
+    total: number;
+    ultimo_atendimento: Date | null;
+  };
+  participacoes: {
+    total_ativas: number;
+  };
+}
+
+export type BeneficiariaAtividadeTipo =
+  | 'formulario'
+  | 'anamnese'
+  | 'ficha_evolucao'
+  | 'termos_consentimento'
+  | 'visao_holistica';
+
+export interface BeneficiariaAtividade {
+  type: BeneficiariaAtividadeTipo;
+  id: number;
+  created_at: Date;
+  created_by: number | null;
+  created_by_name?: string | null;
+}
+
+export interface BeneficiariaAtividadeLista {
+  data: BeneficiariaAtividade[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.1.0",
         "@types/exceljs": "^1.3.2",
         "@types/pdfkit": "^0.17.2",
         "bcryptjs": "^2.4.3",
@@ -84,6 +85,18 @@
         "ts-jest": "^29.1.1",
         "tsx": "^4.6.2",
         "typescript": "^5.3.3"
+      }
+    },
+    "apps/backend/node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.1.0.tgz",
+      "integrity": "sha512-tQFxVs05J/6QXXqIzj6rTRk3nj1HFs4pe+uThwE95jL5II2JfpVXkK+CqkO7aT0Do5AYqO6LDrKpleLUFXgY+g==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "apps/backend/node_modules/@hapi/hoek": {
@@ -782,30 +795,21 @@
         "@types/luxon": "^3.7.1",
         "@types/react-big-calendar": "^1.16.2",
         "axios": "^1.11.0",
-        "bcryptjs": "^3.0.2",
         "chart.js": "^4.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "compression": "^1.8.1",
-        "cookie-parser": "^1.4.7",
         "dayjs": "^1.11.14",
         "embla-carousel-react": "^8.6.0",
-        "express": "^5.1.0",
-        "express-rate-limit": "^8.0.1",
         "file-saver": "^2.0.5",
-        "helmet": "^8.1.0",
         "input-otp": "^1.4.2",
-        "ioredis": "^5.3.2",
         "js-cookie": "^3.0.5",
         "jspdf": "^3.0.1",
         "jspdf-autotable": "^5.0.2",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.462.0",
         "luxon": "^3.7.1",
-        "morgan": "^1.10.1",
         "next-themes": "^0.3.0",
-        "pg": "^8.16.3",
         "react": "^18.3.1",
         "react-big-calendar": "^1.19.4",
         "react-chartjs-2": "^5.3.0",
@@ -815,16 +819,12 @@
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
         "recharts": "^2.15.4",
-        "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "sonner": "^1.7.4",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
-        "winston": "^3.17.0",
-        "winston-daily-rotate-file": "^5.0.0",
         "xlsx": "^0.18.5",
-        "xss-clean": "^0.1.4",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -839,8 +839,6 @@
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^14.1.0",
         "@testing-library/user-event": "^14.5.0",
-        "@types/express": "^5.0.3",
-        "@types/express-serve-static-core": "^5.0.7",
         "@types/file-saver": "^2.0.7",
         "@types/jest": "^30.0.0",
         "@types/joi": "^17.2.3",
@@ -9492,26 +9490,6 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -10269,14 +10247,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -10335,25 +10305,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT"
-    },
-    "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -11339,17 +11290,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/content-type": {
@@ -13118,47 +13058,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/express-mongo-sanitize": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
@@ -13166,31 +13065,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/express-rate-limit": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
-      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
-      "dependencies": {
-        "ip-address": "10.0.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": ">= 4.11"
-      }
-    },
-    "node_modules/express/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "engines": {
-        "node": ">=6.6.0"
       }
     },
     "node_modules/extract-css": {
@@ -13447,22 +13321,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -13652,14 +13510,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -14038,14 +13888,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/hpp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/hpp/-/hpp-0.2.3.tgz",
@@ -14409,6 +14251,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -14821,11 +14664,6 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -18733,14 +18571,6 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
-    "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/mediaquery-text": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mediaquery-text/-/mediaquery-text-1.2.0.tgz",
@@ -18754,17 +18584,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -18829,17 +18648,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -19339,6 +19147,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -19535,14 +19352,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-    },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -20374,6 +20183,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -20424,20 +20234,6 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/react": {
@@ -21129,21 +20925,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -21258,41 +21039,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-      "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/set-function-length": {
@@ -21915,14 +21661,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
-    },
-    "node_modules/statuses": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/std-env": {
       "version": "3.9.0",
@@ -23089,19 +22827,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -24258,23 +23983,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-daily-rotate-file": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
-      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
-      "dependencies": {
-        "file-stream-rotator": "^0.6.1",
-        "object-hash": "^3.0.0",
-        "triple-beam": "^1.4.1",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {


### PR DESCRIPTION
## Summary
- restructure the beneficiárias service to use the repository, add cached resumo and atividades helpers, and centralize cache invalidation
- expose resumo and atividades queries from the beneficiárias repository and update the HTTP routes to rely on the service and return DTO responses
- extend integration coverage for beneficiárias, add unit tests for the service cache behaviour, and update configuration route mocks for new middleware

## Testing
- `cd apps/backend && npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d86239df508324be65c8b43540063d