### PR TITLE
feat(frontend): refactor dashboard data fetching with react-query

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useDashboard.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useDashboard.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { apiService } from '@/services/apiService';
+import {
+  useDashboardStats,
+  useDashboardActivities,
+  useDashboardTasks,
+  useInvalidateDashboard,
+  defaultDashboardStats,
+  dashboardKeys,
+} from '../useDashboard';
+import { translateErrorMessage } from '@/lib/apiError';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { Wrapper, queryClient };
+}
+
+describe('useDashboard hooks', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('retorna estatísticas normalizadas com sucesso', async () => {
+    const { Wrapper } = createWrapper();
+
+    vi.spyOn(apiService, 'getDashboardStats').mockResolvedValue({
+      success: true,
+      data: {
+        totalBeneficiarias: '5',
+        activeBeneficiarias: 3,
+        inactiveBeneficiarias: 2,
+        totalFormularios: '10',
+        totalAtendimentos: 4,
+        engajamento: 75,
+      },
+    } as any);
+
+    const { result } = renderHook(() => useDashboardStats(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        totalBeneficiarias: 5,
+        beneficiariasAtivas: 3,
+        beneficiariasInativas: 2,
+        formularios: 10,
+        atendimentosMes: 4,
+        engajamento: '75%',
+      });
+    });
+  });
+
+  it('usa valores padrão quando não há dados de estatística', async () => {
+    const { Wrapper } = createWrapper();
+
+    vi.spyOn(apiService, 'getDashboardStats').mockResolvedValue({
+      success: true,
+      data: undefined,
+    } as any);
+
+    const { result } = renderHook(() => useDashboardStats(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(defaultDashboardStats);
+    });
+  });
+
+  it('propaga erro traduzido ao carregar estatísticas', async () => {
+    const { Wrapper } = createWrapper();
+    const errorMessage = 'Erro interno do servidor';
+
+    vi.spyOn(apiService, 'getDashboardStats').mockResolvedValue({
+      success: false,
+      message: errorMessage,
+    } as any);
+
+    const { result } = renderHook(() => useDashboardStats(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe(translateErrorMessage(errorMessage));
+  });
+
+  it('retorna lista de atividades', async () => {
+    const { Wrapper } = createWrapper();
+    const activities = [{ id: 1 }, { id: 2 }];
+
+    vi.spyOn(apiService, 'getDashboardActivities').mockResolvedValue({
+      success: true,
+      data: activities,
+    } as any);
+
+    const { result } = renderHook(() => useDashboardActivities(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(activities);
+    });
+  });
+
+  it('retorna lista de tarefas', async () => {
+    const { Wrapper } = createWrapper();
+    const tasks = [{ id: 'a' }];
+
+    vi.spyOn(apiService, 'getDashboardTasks').mockResolvedValue({
+      success: true,
+      data: tasks,
+    } as any);
+
+    const { result } = renderHook(() => useDashboardTasks(), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(tasks);
+    });
+  });
+
+  it('retorna listas vazias quando a API falha para atividades e tarefas', async () => {
+    const { Wrapper } = createWrapper();
+    const errorMessage = 'Erro 500';
+
+    vi.spyOn(apiService, 'getDashboardActivities').mockResolvedValue({
+      success: false,
+      message: errorMessage,
+    } as any);
+
+    const activitiesHook = renderHook(() => useDashboardActivities(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(activitiesHook.result.current.isError).toBe(true));
+    expect(activitiesHook.result.current.error?.message).toBe(translateErrorMessage(errorMessage));
+
+    vi.spyOn(apiService, 'getDashboardTasks').mockResolvedValue({
+      success: false,
+      message: errorMessage,
+    } as any);
+
+    const tasksHook = renderHook(() => useDashboardTasks(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(tasksHook.result.current.isError).toBe(true));
+    expect(tasksHook.result.current.error?.message).toBe(translateErrorMessage(errorMessage));
+  });
+
+  it('invalida caches relevantes', () => {
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useInvalidateDashboard(), { wrapper: Wrapper });
+
+    result.current.invalidateAll();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: dashboardKeys.all });
+
+    result.current.invalidateStats();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: dashboardKeys.stats() });
+
+    result.current.invalidateActivities();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: dashboardKeys.activities() });
+
+    result.current.invalidateTasks();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: dashboardKeys.tasks() });
+  });
+});
+

--- a/apps/frontend/src/hooks/useDashboard.ts
+++ b/apps/frontend/src/hooks/useDashboard.ts
@@ -1,0 +1,158 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { apiService } from '@/services/apiService';
+import { translateErrorMessage } from '@/lib/apiError';
+import type { DashboardStatsResponse } from '@/types/dashboard';
+
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+  stats: () => [...dashboardKeys.all, 'stats'] as const,
+  activities: () => [...dashboardKeys.all, 'activities'] as const,
+  tasks: () => [...dashboardKeys.all, 'tasks'] as const,
+};
+
+export interface DashboardStatsSummary {
+  totalBeneficiarias: number;
+  beneficiariasAtivas: number;
+  beneficiariasInativas: number;
+  formularios: number;
+  atendimentosMes: number;
+  engajamento: string;
+}
+
+export interface DashboardActivity {
+  id: string | number;
+  icon?: string;
+  type?: string;
+  description?: string;
+  time?: string | Date;
+  [key: string]: unknown;
+}
+
+export interface DashboardTask {
+  id: string | number;
+  title?: string;
+  due?: string;
+  priority?: string;
+  [key: string]: unknown;
+}
+
+export const defaultDashboardStats: DashboardStatsSummary = {
+  totalBeneficiarias: 0,
+  beneficiariasAtivas: 0,
+  beneficiariasInativas: 0,
+  formularios: 0,
+  atendimentosMes: 0,
+  engajamento: '0%',
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function normalizeStats(data?: DashboardStatsResponse | null): DashboardStatsSummary {
+  if (!data) {
+    return { ...defaultDashboardStats };
+  }
+
+  const engajamentoValor = (() => {
+    if (typeof data.engajamento === 'number') {
+      return data.engajamento;
+    }
+    if (typeof data.engajamento === 'string') {
+      const parsed = Number.parseFloat(data.engajamento.replace(/%/g, ''));
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+  })();
+
+  return {
+    totalBeneficiarias: toNumber(data.totalBeneficiarias),
+    beneficiariasAtivas: toNumber(data.activeBeneficiarias),
+    beneficiariasInativas: toNumber(data.inactiveBeneficiarias),
+    formularios: toNumber(data.totalFormularios),
+    atendimentosMes: toNumber(data.totalAtendimentos),
+    engajamento: `${engajamentoValor}%`,
+  };
+}
+
+type StatsQueryOptions = Omit<
+  UseQueryOptions<DashboardStatsSummary, Error, DashboardStatsSummary, ReturnType<typeof dashboardKeys.stats>>,
+  'queryKey' | 'queryFn'
+>;
+
+type ActivitiesQueryOptions = Omit<
+  UseQueryOptions<DashboardActivity[], Error, DashboardActivity[], ReturnType<typeof dashboardKeys.activities>>,
+  'queryKey' | 'queryFn'
+>;
+
+type TasksQueryOptions = Omit<
+  UseQueryOptions<DashboardTask[], Error, DashboardTask[], ReturnType<typeof dashboardKeys.tasks>>,
+  'queryKey' | 'queryFn'
+>;
+
+export function useDashboardStats(options?: StatsQueryOptions) {
+  return useQuery({
+    queryKey: dashboardKeys.stats(),
+    queryFn: async () => {
+      const response = await apiService.getDashboardStats();
+      if (!response.success) {
+        throw new Error(translateErrorMessage(response.message));
+      }
+      return normalizeStats(response.data ?? null);
+    },
+    placeholderData: defaultDashboardStats,
+    ...options,
+  });
+}
+
+export function useDashboardActivities(options?: ActivitiesQueryOptions) {
+  return useQuery({
+    queryKey: dashboardKeys.activities(),
+    queryFn: async () => {
+      const response = await apiService.getDashboardActivities();
+      if (!response.success) {
+        throw new Error(translateErrorMessage(response.message));
+      }
+      return Array.isArray(response.data) ? response.data : [];
+    },
+    initialData: [],
+    ...options,
+  });
+}
+
+export function useDashboardTasks(options?: TasksQueryOptions) {
+  return useQuery({
+    queryKey: dashboardKeys.tasks(),
+    queryFn: async () => {
+      const response = await apiService.getDashboardTasks();
+      if (!response.success) {
+        throw new Error(translateErrorMessage(response.message));
+      }
+      return Array.isArray(response.data) ? response.data : [];
+    },
+    initialData: [],
+    ...options,
+  });
+}
+
+export function useInvalidateDashboard() {
+  const queryClient = useQueryClient();
+
+  return {
+    invalidateAll: () => queryClient.invalidateQueries({ queryKey: dashboardKeys.all }),
+    invalidateStats: () => queryClient.invalidateQueries({ queryKey: dashboardKeys.stats() }),
+    invalidateActivities: () => queryClient.invalidateQueries({ queryKey: dashboardKeys.activities() }),
+    invalidateTasks: () => queryClient.invalidateQueries({ queryKey: dashboardKeys.tasks() }),
+  };
+}
+

--- a/apps/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/apps/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import type { UseQueryResult } from '@tanstack/react-query';
+import Dashboard from '../Dashboard';
+import type { DashboardStatsSummary, DashboardActivity, DashboardTask } from '@/hooks/useDashboard';
+
+const toastMock = vi.fn();
+
+vi.mock('@/components/ui/use-toast', () => {
+  return {
+    useToast: () => ({
+      toast: toastMock,
+    }),
+  };
+});
+
+const createQueryResult = <T,>(
+  overrides: Partial<UseQueryResult<T, Error>> = {},
+): UseQueryResult<T, Error> => ({
+  data: undefined,
+  error: null,
+  isLoading: false,
+  isError: false,
+  status: 'success',
+  fetchStatus: 'idle',
+  refetch: vi.fn(),
+  isFetching: false,
+  isSuccess: true,
+  failureCount: 0,
+  isFetched: true,
+  isFetchedAfterMount: true,
+  isFetchingNextPage: false,
+  isFetchingPreviousPage: false,
+  isInitialLoading: false,
+  isPaused: false,
+  isPlaceholderData: false,
+  isRefetchError: false,
+  isRefetching: false,
+  dataUpdatedAt: 0,
+  errorUpdatedAt: 0,
+  ...overrides,
+} as UseQueryResult<T, Error>);
+
+const statsMock = vi.fn<[], UseQueryResult<DashboardStatsSummary, Error>>();
+const activitiesMock = vi.fn<[], UseQueryResult<DashboardActivity[], Error>>();
+const tasksMock = vi.fn<[], UseQueryResult<DashboardTask[], Error>>();
+
+vi.mock('@/hooks/useDashboard', () => ({
+  useDashboardStats: () => statsMock(),
+  useDashboardActivities: () => activitiesMock(),
+  useDashboardTasks: () => tasksMock(),
+  defaultDashboardStats: {
+    totalBeneficiarias: 0,
+    beneficiariasAtivas: 0,
+    beneficiariasInativas: 0,
+    formularios: 0,
+    atendimentosMes: 0,
+    engajamento: '0%',
+  },
+}));
+
+describe('Dashboard page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    toastMock.mockClear();
+  });
+
+  const renderDashboard = () =>
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>,
+    );
+
+  it('exibe estatísticas e listas quando carregamento é bem sucedido', () => {
+    statsMock.mockReturnValue(
+      createQueryResult<DashboardStatsSummary>({
+        data: {
+          totalBeneficiarias: 10,
+          beneficiariasAtivas: 7,
+          beneficiariasInativas: 3,
+          formularios: 5,
+          atendimentosMes: 2,
+          engajamento: '50%',
+        },
+      }),
+    );
+    activitiesMock.mockReturnValue(
+      createQueryResult<DashboardActivity[]>({
+        data: [
+          { id: 1, type: 'Teste', description: 'Descrição', time: new Date().toISOString() },
+        ],
+      }),
+    );
+    tasksMock.mockReturnValue(
+      createQueryResult<DashboardTask[]>({
+        data: [
+          { id: 1, title: 'Tarefa', due: '2024-01-01', priority: 'Alta' },
+        ],
+      }),
+    );
+
+    renderDashboard();
+
+    expect(screen.getByTestId('stats-beneficiarias-count')).toHaveTextContent('10');
+    expect(screen.getByText('Descrição')).toBeInTheDocument();
+    expect(screen.getByText('Tarefa')).toBeInTheDocument();
+  });
+
+  it('exibe estados de carregamento quando consultas ainda estão carregando', () => {
+    const loadingResult = createQueryResult({
+      isLoading: true,
+      isSuccess: false,
+      status: 'pending',
+    });
+
+    statsMock.mockReturnValue(loadingResult);
+    activitiesMock.mockReturnValue(loadingResult);
+    tasksMock.mockReturnValue(loadingResult);
+
+    renderDashboard();
+
+    expect(screen.getAllByText('Carregando...').length).toBeGreaterThan(0);
+    expect(screen.getByText('Carregando atividades...')).toBeInTheDocument();
+    expect(screen.getByText('Carregando tarefas...')).toBeInTheDocument();
+  });
+
+  it('exibe mensagens de erro e dispara toast quando consultas falham', () => {
+    const error = new Error('Erro interno do servidor');
+    const errorResult = createQueryResult({
+      isError: true,
+      isSuccess: false,
+      error,
+      status: 'error',
+    });
+
+    statsMock.mockReturnValue(errorResult);
+    activitiesMock.mockReturnValue(errorResult);
+    tasksMock.mockReturnValue(errorResult);
+
+    renderDashboard();
+
+    expect(screen.getAllByText(/Erro interno do servidor/).length).toBeGreaterThan(0);
+    expect(toastMock).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add dedicated React Query hooks for dashboard stats, activities, and tasks along with cache invalidation helpers
- refactor the dashboard page to consume the new hooks and surface translated error feedback
- add hook and page tests covering loading, success, and error scenarios

## Testing
- npx vitest run src/hooks/__tests__/useDashboard.test.tsx src/pages/__tests__/Dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d8623abdd48324bd8eac752f6ef424