### PR TITLE
Refactor frontend auth to rely on httpOnly cookies

### DIFF
--- a/apps/frontend/src/hooks/useSocket.ts
+++ b/apps/frontend/src/hooks/useSocket.ts
@@ -40,14 +40,6 @@ const useSocket = (socketUrl?: string) => {
       return;
     }
 
-    // Obter token do localStorage
-    // O app salva o JWT com a chave 'token' (ver usePostgreSQLAuth.tsx)
-    const token = localStorage.getItem('token');
-    if (!token) {
-      console.warn('Token não encontrado');
-      return;
-    }
-
     // Conectar ao socket apenas se estiver autenticado
     const WS_URL = socketUrl
       ?? (import.meta as any)?.env?.VITE_WS_URL
@@ -55,7 +47,7 @@ const useSocket = (socketUrl?: string) => {
     const socket = io(
       WS_URL,
       {
-        auth: { token },
+        withCredentials: true,
         transports: ['websocket', 'polling']
       }
     );
@@ -155,7 +147,7 @@ const useSocket = (socketUrl?: string) => {
       socketRef.current = null;
       setIsConnected(false);
     };
-  }, [isAuthenticated, profile]);
+  }, [isAuthenticated, profile, socketUrl]);
 
   // Função para enviar mensagem via socket
   const sendMessage = (destinatarioId: string, conteudo: string, remetente_nome?: string) => {

--- a/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
+++ b/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
@@ -132,8 +132,7 @@ export default function DeclaracoesReciboGeral() {
         // Fazer download do PDF usando utilitário
         const declaracaoId = (response.data as any)?.declaracao?.id;
         if (declaracaoId) {
-          const token = localStorage.getItem('token') || '';
-          const downloadOk = await downloadDeclaracao(declaracaoId, token);
+          const downloadOk = await downloadDeclaracao(declaracaoId);
           
           if (!downloadOk) {
             toast({
@@ -201,8 +200,7 @@ export default function DeclaracoesReciboGeral() {
         // Fazer download do PDF usando utilitário
         const reciboId = (response.data as any)?.recibo?.id;
         if (reciboId) {
-          const token = localStorage.getItem('token') || '';
-          const downloadOk = await downloadRecibo(reciboId, token);
+          const downloadOk = await downloadRecibo(reciboId);
           
           if (!downloadOk) {
             toast({

--- a/apps/frontend/src/pages/formularios/DeclaracoesRecibos.tsx
+++ b/apps/frontend/src/pages/formularios/DeclaracoesRecibos.tsx
@@ -95,8 +95,7 @@ export default function DeclaracoesRecibos() {
         // Fazer download do PDF usando utilitário
         const declaracaoId = (response.data as any)?.declaracao?.id;
         if (declaracaoId) {
-          const token = localStorage.getItem('token') || '';
-          const downloadOk = await downloadDeclaracao(declaracaoId, token);
+          const downloadOk = await downloadDeclaracao(declaracaoId);
           
           if (!downloadOk) {
             alert('PDF gerado, mas houve problema no download. Verifique se permite downloads neste site.');
@@ -133,8 +132,7 @@ export default function DeclaracoesRecibos() {
         // Fazer download do PDF usando utilitário
         const reciboId = (response.data as any)?.recibo?.id;
         if (reciboId) {
-          const token = localStorage.getItem('token') || '';
-          const downloadOk = await downloadRecibo(reciboId, token);
+          const downloadOk = await downloadRecibo(reciboId);
           
           if (!downloadOk) {
             alert('PDF gerado, mas houve problema no download. Verifique se permite downloads neste site.');

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -2,7 +2,7 @@ import api from '@/config/api';
 import axios from 'axios';
 
 export interface AuthResponse {
-  token: string;
+  token?: string;
   user: {
     id: number;
     email: string;
@@ -19,6 +19,7 @@ export interface LoginCredentials {
 
 export class AuthService {
   private static instance: AuthService;
+  private currentUser: AuthResponse['user'] | null = null;
 
   private constructor() {}
 
@@ -32,6 +33,9 @@ export class AuthService {
   async login(credentials: LoginCredentials): Promise<AuthResponse> {
     try {
       const response = await api.post<AuthResponse>('/auth/login', credentials, { withCredentials: true });
+      if (response.data?.user) {
+        this.currentUser = response.data.user;
+      }
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -44,34 +48,43 @@ export class AuthService {
   async logout(): Promise<void> {
     try {
       await api.post('/auth/logout', undefined, { withCredentials: true });
-      // Limpar token e dados do usuário localmente
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('user');
+      this.currentUser = null;
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     }
   }
 
-  async refreshToken(): Promise<string> {
+  async refreshToken(): Promise<void> {
     try {
-      const response = await api.post<{ message: string; token: string }>('/auth/refresh', undefined, { withCredentials: true });
-      return response.data.token;
+      await api.post('/auth/refresh', undefined, { withCredentials: true });
     } catch (error) {
       throw new Error('Erro ao renovar token');
     }
   }
 
-  isAuthenticated(): boolean {
-    const token = localStorage.getItem('auth_token');
-    return !!token;
+  async fetchCurrentUser(): Promise<AuthResponse['user']> {
+    try {
+      const response = await api.get<{ user: AuthResponse['user'] }>('/auth/me', { withCredentials: true });
+      this.currentUser = response.data.user;
+      return response.data.user;
+    } catch (error) {
+      this.currentUser = null;
+      if (axios.isAxiosError(error)) {
+        throw new Error(error.response?.data?.message || 'Não autenticado');
+      }
+      throw error;
+    }
   }
 
-  getToken(): string | null {
-    return localStorage.getItem('auth_token');
+  isAuthenticated(): boolean {
+    return this.currentUser !== null;
   }
 
   getUser(): AuthResponse['user'] | null {
-    const userStr = localStorage.getItem('user');
-    return userStr ? JSON.parse(userStr) : null;
+    return this.currentUser;
+  }
+
+  clearCachedUser() {
+    this.currentUser = null;
   }
 }

--- a/apps/frontend/src/utils/pdfDownload.ts
+++ b/apps/frontend/src/utils/pdfDownload.ts
@@ -33,7 +33,8 @@ export async function downloadPdf(options: DownloadPdfOptions): Promise<boolean>
     // Fazer requisição para o PDF
     const response = await fetch(endpoint, {
       method: 'GET',
-      headers
+      headers,
+      credentials: 'include'
     });
     
     if (!response.ok) {
@@ -130,12 +131,12 @@ export async function printPdf(endpoint: string, token?: string): Promise<boolea
     const headers: HeadersInit = {
       'Accept': 'application/pdf, text/plain, */*'
     };
-    
+
     if (token) {
       headers['Authorization'] = `Bearer ${token}`;
     }
-    
-    const response = await fetch(endpoint, { headers });
+
+    const response = await fetch(endpoint, { headers, credentials: 'include' });
     
     if (!response.ok) {
       throw new Error(`Erro HTTP: ${response.status}`);

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -86,37 +86,12 @@ export default async function globalSetup(_config: FullConfig) {
       );
     }
 
-    const payload = await response.json();
-    const token: string | undefined = payload?.token;
-    const user = payload?.user ?? {
-      email: testUser.email,
-      nome: testUser.name,
-      papel: testUser.role,
-    };
-
-    if (!token) {
-      throw new Error('Login response did not include a token.');
-    }
+    await response.json().catch(() => null);
 
     const existingState = await apiContext.storageState();
-    const normalizedBaseUrl = baseURL.replace(/\/$/, '');
-    const origins = existingState.origins?.filter(
-      (origin) => origin.origin !== normalizedBaseUrl
-    );
-
     storageState = {
       cookies: existingState.cookies ?? [],
-      origins: [
-        ...(origins ?? []),
-        {
-          origin: normalizedBaseUrl,
-          localStorage: [
-            { name: 'auth_token', value: token },
-            { name: 'token', value: token },
-            { name: 'user', value: JSON.stringify(user) },
-          ],
-        },
-      ],
+      origins: existingState.origins ?? [],
     };
   } catch (error) {
     console.warn(


### PR DESCRIPTION
## Summary
- update AuthService and React auth hooks to load the current user via /auth/me and remove token usage from localStorage
- adjust API service interceptors, websocket hook, and PDF helpers to rely on httpOnly cookies instead of Authorization headers
- refresh end-to-end setup and legacy auth hook to reflect cookie-based authentication

## Testing
- npm run lint:frontend *(fails: repository has widespread Prettier --check warnings outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8623d26b48324b6171a5a83ac251f