### PR TITLE
Restrict admin routes and cover with tests

### DIFF
--- a/apps/frontend/src/components/QuickActions.tsx
+++ b/apps/frontend/src/components/QuickActions.tsx
@@ -1,9 +1,11 @@
 import { Plus, CheckSquare, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
 
 export function QuickActions() {
   const navigate = useNavigate();
+  const { isAdmin } = useAuth();
 
   return (
     <div
@@ -24,13 +26,15 @@ export function QuickActions() {
       >
         <CheckSquare className="h-4 w-4 mr-2" /> Registrar presença
       </Button>
-      <Button
-        variant="outline"
-        className="bg-background shadow-lg"
-        onClick={() => navigate('/relatorios')}
-      >
-        <FileText className="h-4 w-4 mr-2" /> Gerar relatório
-      </Button>
+      {isAdmin && (
+        <Button
+          variant="outline"
+          className="bg-background shadow-lg"
+          onClick={() => navigate('/relatorios')}
+        >
+          <FileText className="h-4 w-4 mr-2" /> Gerar relatório
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { 
-  Users, 
-  FileText, 
-  Heart, 
-  BarChart3, 
-  Settings, 
+import {
+  Users,
+  FileText,
+  Heart,
+  BarChart3,
+  Settings,
   Menu,
   X,
   Home,
@@ -17,14 +17,30 @@ import {
   GraduationCap,
   TrendingUp,
   FolderKanban,
-  MessageSquare
+  MessageSquare,
+  type LucideIcon
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 
-const menuItems = [
+type MenuChild = {
+  title: string;
+  href: string;
+  adminOnly?: boolean;
+};
+
+type MenuItem = {
+  title: string;
+  icon: LucideIcon;
+  href?: string;
+  children?: MenuChild[];
+  adminOnly?: boolean;
+};
+
+const menuItems: MenuItem[] = [
   {
-    title: "Dashboard", 
+    title: "Dashboard",
     icon: Home,
     href: "/dashboard"
   },
@@ -75,12 +91,14 @@ const menuItems = [
   {
     title: "Relatórios",
     icon: BarChart3,
-    href: "/relatorios"
+    href: "/relatorios",
+    adminOnly: true
   },
   {
     title: "Analytics",
     icon: TrendingUp,
-    href: "/analytics"
+    href: "/analytics",
+    adminOnly: true
   }
 ];
 
@@ -88,10 +106,28 @@ export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedItems, setExpandedItems] = useState<string[]>(["Formulários"]);
   const location = useLocation();
+  const { isAdmin } = useAuth();
+
+  const filteredMenuItems = useMemo(() =>
+    menuItems
+      .map(item => ({
+        ...item,
+        children: item.children?.filter(child => !child.adminOnly || isAdmin)
+      }))
+      .filter(item => {
+        if (item.adminOnly && !isAdmin) {
+          return false;
+        }
+        if (item.children && item.children.length === 0) {
+          return false;
+        }
+        return true;
+      })
+  , [isAdmin]);
 
   const toggleExpanded = (title: string) => {
-    setExpandedItems(prev => 
-      prev.includes(title) 
+    setExpandedItems(prev =>
+      prev.includes(title)
         ? prev.filter(item => item !== title)
         : [...prev, title]
     );
@@ -143,7 +179,7 @@ export default function Sidebar() {
 
           {/* Navigation */}
           <nav className="flex-1 p-4 space-y-2 overflow-y-auto">
-            {menuItems.map((item) => (
+            {filteredMenuItems.map((item) => (
               <div key={item.title}>
                 {item.children ? (
                   <div>
@@ -211,19 +247,21 @@ export default function Sidebar() {
 
           {/* Footer */}
           <div className="p-4 border-t border-sidebar-border">
-            <NavLink
-              to="/configuracoes"
-              className={({ isActive }) => cn(
-                "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                isActive 
-                  ? "bg-primary text-primary-foreground shadow-soft" 
-                  : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              )}
-              onClick={() => setIsOpen(false)}
-            >
-              <Settings className="h-4 w-4" />
-              Configurações
-            </NavLink>
+            {isAdmin && (
+              <NavLink
+                to="/configuracoes"
+                className={({ isActive }) => cn(
+                  "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-soft"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+                onClick={() => setIsOpen(false)}
+              >
+                <Settings className="h-4 w-4" />
+                Configurações
+              </NavLink>
+            )}
           </div>
         </div>
       </aside>

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom";
 import { apiService } from "@/services/apiService";
 import type { DashboardStatsResponse } from "@/types/dashboard";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 
 // Componente StatCard local
 interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
@@ -55,6 +56,7 @@ const StatCard = ({
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const { isAdmin } = useAuth();
   const [stats, setStats] = useState({
     totalBeneficiarias: 0,
     beneficiariasAtivas: 0,
@@ -279,10 +281,12 @@ export default function Dashboard() {
               <Calendar className="h-6 w-6" />
               <span className="text-sm">Agendamentos</span>
             </Button>
-            <Button variant="outline" className="h-auto p-4 flex-col gap-2" onClick={() => navigate('/relatorios')}>
-              <TrendingUp className="h-6 w-6" />
-              <span className="text-sm">Relatórios</span>
-            </Button>
+            {isAdmin && (
+              <Button variant="outline" className="h-auto p-4 flex-col gap-2" onClick={() => navigate('/relatorios')}>
+                <TrendingUp className="h-6 w-6" />
+                <span className="text-sm">Relatórios</span>
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/apps/frontend/src/routes/__tests__/features.routes.test.tsx
+++ b/apps/frontend/src/routes/__tests__/features.routes.test.tsx
@@ -1,0 +1,129 @@
+import { Suspense } from "react";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import { FeaturesRoutes } from "../features.routes";
+import { useAuth } from "@/hooks/useAuth";
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: vi.fn()
+}));
+
+vi.mock("@/services/apiService", () => ({
+  apiService: {
+    getDashboardStats: vi.fn().mockResolvedValue({ success: true, data: {} })
+  }
+}));
+
+vi.mock("@/services/api", () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: [] }),
+    post: vi.fn().mockResolvedValue({ data: null }),
+    delete: vi.fn().mockResolvedValue({})
+  }
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+
+const renderWithRouter = (initialEntry: string) => {
+  const featuresTree = FeaturesRoutes({});
+  const children = (featuresTree as any)?.props?.children;
+  const featureRoutes = Array.isArray(children)
+    ? children
+    : children
+      ? [children]
+      : [];
+
+  const Layout = () => <Outlet />;
+
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Suspense fallback={<div>Carregando...</div>}>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<div>Home</div>} />
+            {featureRoutes}
+          </Route>
+        </Routes>
+      </Suspense>
+    </MemoryRouter>
+  );
+};
+
+const baseAuthState = {
+  user: {
+    id: 1,
+    nome: "Usuário Teste",
+    email: "teste@example.com",
+    papel: "admin",
+    ativo: true
+  },
+  profile: null,
+  loading: false,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  isAuthenticated: true,
+  isAdmin: true
+};
+
+describe("FeaturesRoutes RBAC", () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReset();
+  });
+
+  it("permite que administradores acessem a rota de analytics", async () => {
+    mockedUseAuth.mockReturnValue(baseAuthState);
+    renderWithRouter("/analytics");
+
+    expect(
+      await screen.findByRole("heading", { name: /analytics/i })
+    ).toBeInTheDocument();
+  });
+
+  it("redireciona usuários comuns ao tentar acessar analytics", async () => {
+    mockedUseAuth.mockReturnValue({
+      ...baseAuthState,
+      isAdmin: false,
+      user: { ...baseAuthState.user, papel: "profissional" }
+    });
+
+    renderWithRouter("/analytics");
+
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: /analytics/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("permite que administradores acessem a rota de relatórios", async () => {
+    mockedUseAuth.mockReturnValue(baseAuthState);
+
+    renderWithRouter("/relatorios");
+
+    expect(
+      await screen.findByRole("heading", { name: /relatórios/i })
+    ).toBeInTheDocument();
+  });
+
+  it("redireciona usuários comuns ao tentar acessar relatórios", async () => {
+    mockedUseAuth.mockReturnValue({
+      ...baseAuthState,
+      isAdmin: false,
+      user: { ...baseAuthState.user, papel: "profissional" }
+    });
+
+    renderWithRouter("/relatorios");
+
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: /relatórios/i })
+    ).not.toBeInTheDocument();
+  });
+});
+

--- a/apps/frontend/src/routes/features.routes.tsx
+++ b/apps/frontend/src/routes/features.routes.tsx
@@ -1,5 +1,6 @@
 import { lazy } from "react";
 import { Route } from "react-router-dom";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 // Lazy loaded components
 const Analytics = lazy(() => import("@/pages/Analytics"));
@@ -15,7 +16,14 @@ const NotificationsPage = lazy(() => import("@/pages/Notifications"));
 
 export const FeaturesRoutes = () => (
   <>
-    <Route path="analytics" element={<Analytics />} />
+    <Route
+      path="analytics"
+      element={(
+        <ProtectedRoute adminOnly>
+          <Analytics />
+        </ProtectedRoute>
+      )}
+    />
     <Route path="oficinas" element={<OficinasNew />} />
     <Route path="participantes" element={<ParticipantesIndisponivel />} />
     <Route path="chat-interno" element={<ChatInterno />} />
@@ -23,7 +31,14 @@ export const FeaturesRoutes = () => (
     <Route path="calendar" element={<CalendarPage />} />
     <Route path="feed" element={<FeedNew />} />
     <Route path="projetos" element={<ProjetosNew />} />
-    <Route path="relatorios" element={<Relatorios />} />
+    <Route
+      path="relatorios"
+      element={(
+        <ProtectedRoute adminOnly>
+          <Relatorios />
+        </ProtectedRoute>
+      )}
+    />
     <Route path="notifications" element={<NotificationsPage />} />
   </>
 );


### PR DESCRIPTION
## Summary
- hide admin-only navigation links in the sidebar, dashboard shortcuts, and quick actions based on the authenticated role
- guard analytics and reports feature routes behind the admin ProtectedRoute wrapper
- add routing tests that assert analytics/reports access for admins and redirection for non-admin users

## Testing
- `npx vitest run src/routes/__tests__/features.routes.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d8624c290c8324a7705488252e73fb