### PR TITLE
feat(backend): centralize security middleware registration

### DIFF
--- a/apps/backend/src/__tests__/security.middleware.test.ts
+++ b/apps/backend/src/__tests__/security.middleware.test.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import request from 'supertest';
+
+import { applySecurity } from '../middleware/security.middleware';
+
+describe('Security middleware', () => {
+  it('applies expected security headers', async () => {
+    const app = express();
+    applySecurity(app);
+    app.get('/health-check', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const response = await request(app).get('/health-check');
+
+    expect(response.headers).toHaveProperty('x-dns-prefetch-control', 'off');
+    expect(response.headers).toHaveProperty('x-content-type-options', 'nosniff');
+    expect(response.headers).toHaveProperty('x-frame-options', 'SAMEORIGIN');
+    expect(response.headers).toHaveProperty('content-security-policy');
+  });
+});

--- a/apps/backend/src/config/security.ts
+++ b/apps/backend/src/config/security.ts
@@ -82,16 +82,17 @@ const sanitizeInput = (req: Request, _res: Response, next: NextFunction) => {
 };
 
 // Middleware para validar origem das requisições
-const validateOrigin = (req: Request, res: Response, next: NextFunction) => {
+const validateOrigin = (req: Request, res: Response, next: NextFunction): void => {
   const origin = req.get('origin');
   
   if (process.env.NODE_ENV === 'production' && origin) {
     const allowedOrigins = [process.env.FRONTEND_URL!].filter(Boolean);
     
     if (!allowedOrigins.includes(origin)) {
-      return res.status(403).json({
+      res.status(403).json({
         error: 'Origem não permitida'
       });
+      return;
     }
   }
   
@@ -99,14 +100,15 @@ const validateOrigin = (req: Request, res: Response, next: NextFunction) => {
 };
 
 // Middleware para validar content-type
-const validateContentType = (req: Request, res: Response, next: NextFunction) => {
+const validateContentType = (req: Request, res: Response, next: NextFunction): void => {
   if (req.method === 'POST' || req.method === 'PUT') {
     const contentType = req.get('content-type');
     
     if (!contentType || !contentType.includes('application/json')) {
-      return res.status(415).json({
+      res.status(415).json({
         error: 'Content-Type deve ser application/json'
       });
+      return;
     }
   }
   

--- a/apps/backend/src/middleware/security.middleware.ts
+++ b/apps/backend/src/middleware/security.middleware.ts
@@ -1,25 +1,38 @@
-[{
-        "resource": "/workspaces/assist-move-assist/apps/backend/src/middleware/security.middleware.ts",
-	"owner": "typescript",
-	"code": "2339",
-	"severity": 8,
-	"message": "A propriedade 'json' não existe no tipo 'typeof import(\"express\")'.",
-	"source": "ts",
-	"startLineNumber": 71,
-	"startColumn": 17,
-	"endLineNumber": 71,
-	"endColumn": 21,
-	"origin": "extHost2"
-},{
-        "resource": "/workspaces/assist-move-assist/apps/backend/src/middleware/security.middleware.ts",
-	"owner": "typescript",
-	"code": "2339",
-	"severity": 8,
-	"message": "A propriedade 'urlencoded' não existe no tipo 'typeof import(\"express\")'.",
-	"source": "ts",
-	"startLineNumber": 78,
-	"startColumn": 17,
-	"endLineNumber": 78,
-	"endColumn": 27,
-	"origin": "extHost2"
-}]
+import type { Express } from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import hpp from 'hpp';
+
+import {
+  apiLimiter,
+  corsOptions,
+  generalLimiter,
+  helmetConfig,
+  sanitizeInput,
+  validateContentType,
+  validateOrigin
+} from '../config/security';
+import { env } from '../config/env';
+import { logger } from '../services/logger';
+
+/**
+ * Register security middlewares for the Express application.
+ */
+export function applySecurity(app: Express): void {
+  app.use(helmet(helmetConfig));
+  app.use(cors(corsOptions));
+  app.use(hpp());
+
+  app.use(sanitizeInput);
+  app.use(validateOrigin);
+  app.use(validateContentType);
+
+  if (!env.RATE_LIMIT_DISABLE) {
+    app.use('/api/', generalLimiter);
+    app.use('/api/v1/', apiLimiter);
+  } else {
+    logger.info('Rate limiting desativado via RATE_LIMIT_DISABLE');
+  }
+}
+
+export default applySecurity;


### PR DESCRIPTION
## Summary
- replace the broken security middleware file with an applySecurity helper that wires helmet, cors, hpp, sanitization, and the configured rate limiters
- invoke the shared security registration when bootstrapping the Express app and keep rate-limit disable logging
- add a Jest test that ensures the main security headers are present and fix type annotations on the origin/content-type validators

## Testing
- npm test --workspace apps/backend -- --runTestsByPath src/__tests__/security.middleware.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d86249bdfc83248d53d6db6789837d