### PR TITLE
Refactor beneficiarias and oficinas pages to use typed hooks

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useBeneficiarias.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useBeneficiarias.test.ts
@@ -5,7 +5,10 @@ import useBeneficiarias from '../useBeneficiarias';
 import { createQueryClientWrapper } from './testUtils';
 
 beforeEach(() => {
-  vi.spyOn(beneficiariasService, 'listar').mockResolvedValue([]);
+  vi.spyOn(beneficiariasService, 'listar').mockResolvedValue({
+    success: true,
+    data: [],
+  });
 });
 
 afterEach(() => {

--- a/apps/frontend/src/hooks/useBeneficiarias.ts
+++ b/apps/frontend/src/hooks/useBeneficiarias.ts
@@ -1,6 +1,12 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { beneficiariasService } from '../services/api';
 import type { Beneficiaria } from '@/types/shared';
+import type {
+  BeneficiariaListResponse,
+  BeneficiariaResponse,
+  BeneficiariaResumoResponse,
+  ListBeneficiariasParams,
+} from '@/types/beneficiarias';
 import { toast } from 'sonner';
 
 // Keys para React Query
@@ -14,14 +20,8 @@ export const beneficiariasKeys = {
 
 // Hook para listar beneficiárias
 // ...existing code...
-export const useBeneficiarias = (params?: {
-  page?: number;
-  limit?: number;
-  search?: string;
-  status?: 'ativa' | 'inativa' | 'pendente' | 'desistente';
-  escolaridade?: string;
-}) => {
-  return useQuery({
+export const useBeneficiarias = (params: ListBeneficiariasParams = {}): UseQueryResult<BeneficiariaListResponse> => {
+  return useQuery<BeneficiariaListResponse>({
     queryKey: beneficiariasKeys.list(params),
     queryFn: () => beneficiariasService.listar(params),
   });
@@ -30,8 +30,8 @@ export const useBeneficiarias = (params?: {
 export default useBeneficiarias;
 
 // Hook para buscar beneficiária por ID
-export const useBeneficiaria = (id: string) => {
-  return useQuery({
+export const useBeneficiaria = (id: string): UseQueryResult<BeneficiariaResponse> => {
+  return useQuery<BeneficiariaResponse>({
     queryKey: beneficiariasKeys.detail(id),
     queryFn: () => beneficiariasService.buscarPorId(id),
     enabled: !!id,
@@ -39,8 +39,8 @@ export const useBeneficiaria = (id: string) => {
 };
 
 // Hook para buscar resumo da beneficiária
-export const useBeneficiariaResumo = (id: string) => {
-  return useQuery({
+export const useBeneficiariaResumo = (id: string): UseQueryResult<BeneficiariaResumoResponse> => {
+  return useQuery<BeneficiariaResumoResponse>({
     queryKey: [...beneficiariasKeys.detail(id), 'resumo'],
     queryFn: () => beneficiariasService.buscarResumo(id),
     enabled: !!id,

--- a/apps/frontend/src/hooks/useOficinas.ts
+++ b/apps/frontend/src/hooks/useOficinas.ts
@@ -1,5 +1,14 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { oficinasService, type Oficina, type CreateOficinaDTO, type UpdateOficinaDTO, type ListOficinasParams, type AddParticipanteDTO } from '../services/oficinas.service';
+import { useQuery, useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { oficinasService } from '../services/oficinas.service';
+import type {
+  AddParticipanteDTO,
+  CreateOficinaDTO,
+  ListOficinasParams,
+  Oficina,
+  OficinaResumo,
+  UpdateOficinaDTO,
+  OficinasApiResponse,
+} from '@/types/oficinas';
 import { toast } from 'sonner';
 
 // Keys para React Query
@@ -15,31 +24,28 @@ export const oficinasKeys = {
 };
 
 // Listar oficinas
-export const useOficinas = (params: ListOficinasParams = {}) => {
-  return useQuery({
+export const useOficinas = (params: ListOficinasParams = {}): UseQueryResult<OficinasApiResponse> =>
+  useQuery<OficinasApiResponse>({
     queryKey: oficinasKeys.list(params),
     queryFn: () => oficinasService.listar(params),
   });
-};
 export default useOficinas;
 
 // Buscar oficina por ID
-export const useOficina = (id: number) => {
-  return useQuery({
+export const useOficina = (id: number) =>
+  useQuery({
     queryKey: oficinasKeys.detail(id),
     queryFn: () => oficinasService.buscarPorId(id),
     enabled: !!id,
   });
-};
 
 // Buscar resumo da oficina
-export const useOficinaResumo = (id: number) => {
-  return useQuery({
+export const useOficinaResumo = (id: number) =>
+  useQuery<{ success: boolean; data?: OficinaResumo; message?: string }>({
     queryKey: oficinasKeys.resumo(id),
     queryFn: () => oficinasService.buscarResumo(id),
     enabled: !!id,
   });
-};
 
 // Criar oficina
 export const useCreateOficina = () => {

--- a/apps/frontend/src/pages/BeneficiariasFixed.tsx
+++ b/apps/frontend/src/pages/BeneficiariasFixed.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search, Plus, Filter, MoreHorizontal, Edit, Eye, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -20,177 +20,98 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { apiService } from "@/services/apiService";
 import { ListSkeleton } from "@/components/ui/list-skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
 import usePersistedFilters from "@/hooks/usePersistedFilters";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useBeneficiarias, useBeneficiaria } from "@/hooks/useBeneficiarias";
+import {
+  buildBeneficiariasStats,
+  deriveBeneficiariaStatus,
+  filterBeneficiarias,
+  formatBeneficiariaDate,
+  formatCpf,
+  generatePaedi,
+  getBeneficiariaBadgeVariant,
+  getBeneficiariaInitials,
+  normalizeBeneficiariaSearch,
+  toStatusFilterValue,
+} from "@/utils/beneficiarias";
+import type { Beneficiaria } from "@/types/shared";
 
-// Tipo correto baseado no banco real
-interface Beneficiaria {
-  id: number;
-  nome_completo: string;
-  cpf: string;
-  data_nascimento: string;
-  telefone?: string;
-  contato1?: string;
-  email?: string;
-  endereco?: string;
-  cidade?: string;
-  estado?: string;
-  cep?: string;
-  escolaridade?: string;
-  profissao?: string;
-  estado_civil?: string;
-  tem_filhos?: boolean;
-  quantidade_filhos?: number;
-  renda_familiar?: number;
-  situacao_vulnerabilidade?: string;
-  observacoes?: string;
-  status?: string;
-  data_criacao: string;
-  data_atualizacao: string;
-  ativo: boolean;
-}
+const ITEMS_PER_PAGE = 10;
+const STATUS_OPTIONS = ["Todas", "Ativa", "Aguardando", "Inativa", "Desistente"] as const;
 
 export default function BeneficiariasFixed() {
   const navigate = useNavigate();
   const [showFilters, setShowFilters] = useState(false);
-  const { state: filterState, set: setFilters } = usePersistedFilters({ key: 'beneficiarias:filters', initial: { search: '', status: 'Todas', programa: 'Todos', page: 1 }});
-  const searchTerm = filterState.search as string;
-  const selectedStatus = filterState.status as string;
-  const programaFilter = filterState.programa as string;
+  const { state: filterState, set: setFilters } = usePersistedFilters({
+    key: 'beneficiarias:filters',
+    initial: { search: '', status: 'Todas', programa: 'Todos', page: 1 }
+  });
+
+  const searchTerm = (filterState.search as string) ?? '';
+  const selectedStatus = (filterState.status as string) ?? 'Todas';
+  const programaFilter = (filterState.programa as string) ?? 'Todos';
   const currentPage = Number(filterState.page || 1);
-  const [itemsPerPage] = useState(10);
-  const [beneficiarias, setBeneficiarias] = useState<Beneficiaria[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [stats, setStats] = useState({
-    total: 0,
-    ativas: 0,
-    aguardando: 0,
-    inativas: 0
-  });
 
-  // Função para obter status da beneficiária baseado nos dados reais
-  const getBeneficiariaStatus = (beneficiaria: Beneficiaria) => {
-    // Usar status do banco ou calcular baseado no campo ativo
-    if (beneficiaria.status) {
-      return beneficiaria.status === 'ativa' ? 'Ativa' : 
-             beneficiaria.status === 'inativa' ? 'Inativa' : 'Aguardando';
-    }
-    
-    // Fallback: usar campo ativo
-    return beneficiaria.ativo ? 'Ativa' : 'Inativa';
-  };
+  const statusFilter = (selectedStatus || 'Todas') as 'Todas' | 'Ativa' | 'Aguardando' | 'Inativa' | 'Desistente';
 
-  useEffect(() => {
-    loadBeneficiarias();
-  }, []);
+  const { hasSearch } = useMemo(() => normalizeBeneficiariaSearch(searchTerm), [searchTerm]);
 
-  const loadBeneficiarias = async () => {
-    try {
-      setLoading(true);
-      
-      // Usar apiService consistente
-      const response = await apiService.getBeneficiarias();
-      console.log('Resposta API beneficiárias:', response);
-      
-      if (response.success && response.data) {
-        const data = response.data;
-        setBeneficiarias(data);
-        // Prefetch detalhes do primeiro item
-        if (Array.isArray(data) && data.length > 0) {
-          void apiService.getBeneficiaria(data[0].id);
-        }
-        
-        // Calculate stats com status real do banco
-        const total = data.length;
-        const ativas = data.filter(b => getBeneficiariaStatus(b) === 'Ativa').length;
-        const inativas = data.filter(b => getBeneficiariaStatus(b) === 'Inativa').length;
-        const aguardando = data.filter(b => getBeneficiariaStatus(b) === 'Aguardando').length;
-        
-        setStats({
-          total,
-          ativas,
-          aguardando,
-          inativas
-        });
-      } else {
-        console.error('Erro na resposta:', response);
-        setBeneficiarias([]);
-        setStats({ total: 0, ativas: 0, aguardando: 0, inativas: 0 });
-      }
-    } catch (error) {
-      console.error('Erro ao carregar beneficiárias:', error);
-      setBeneficiarias([]);
-      setStats({ total: 0, ativas: 0, aguardando: 0, inativas: 0 });
-    } finally {
-      setLoading(false);
-    }
-  };
+  const queryFilters = useMemo(
+    () => ({
+      search: searchTerm.trim() ? searchTerm.trim() : undefined,
+      status: toStatusFilterValue(statusFilter),
+    }),
+    [searchTerm, statusFilter]
+  );
 
-  const filteredBeneficiarias = beneficiarias.filter(beneficiaria => {
-    const matchesSearch = beneficiaria.nome_completo.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (beneficiaria.cpf && beneficiaria.cpf.includes(searchTerm));
-    
-    const beneficiariaStatus = getBeneficiariaStatus(beneficiaria);
-    const matchesStatus = selectedStatus === "Todas" || selectedStatus === beneficiariaStatus;
-    
-    // Como não temos campo programa_servico, vamos usar sempre true para programaFilter
-    const matchesPrograma = programaFilter === "Todos";
-    
-    return matchesSearch && matchesStatus && matchesPrograma;
-  });
+  const beneficiariasQuery = useBeneficiarias(queryFilters);
+  const beneficiariasResponse = beneficiariasQuery.data;
+  const beneficiarias: Beneficiaria[] = useMemo(() => {
+    if (beneficiariasResponse?.success === false) return [];
+    const data = beneficiariasResponse?.data;
+    return Array.isArray(data) ? data : [];
+  }, [beneficiariasResponse]);
 
-  // Pagination logic
-  const totalPages = Math.ceil(filteredBeneficiarias.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
+  const firstBeneficiariaId = beneficiarias.length > 0 ? String(beneficiarias[0].id) : '';
+  useBeneficiaria(firstBeneficiariaId);
+
+  const stats = useMemo(() => buildBeneficiariasStats(beneficiarias), [beneficiarias]);
+
+  const filteredBeneficiarias = useMemo(
+    () =>
+      filterBeneficiarias(beneficiarias, {
+        search: searchTerm,
+        status: statusFilter,
+        programa: programaFilter,
+      }),
+    [beneficiarias, programaFilter, searchTerm, statusFilter]
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filteredBeneficiarias.length / ITEMS_PER_PAGE));
+  const safePage = Math.min(Math.max(currentPage, 1), totalPages);
+  const startIndex = (safePage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
   const paginatedBeneficiarias = filteredBeneficiarias.slice(startIndex, endIndex);
+  const showingFrom = filteredBeneficiarias.length === 0 ? 0 : startIndex + 1;
+  const showingTo = Math.min(endIndex, filteredBeneficiarias.length);
 
-  // Reset page quando filtros mudam, mas só se não estiver já na página 1
-  useEffect(() => {
-    if (currentPage !== 1) {
-      setFilters({ page: 1 });
-    }
-  }, [searchTerm, selectedStatus, programaFilter, setFilters]);
-
-  const getStatusVariant = (status: string) => {
-    switch (status) {
-      case "Ativa": return "default";
-      case "Aguardando": return "secondary";
-      case "Inativa": return "outline";
-      default: return "default";
-    }
-  };
-
-  const getInitials = (nome?: string | null) => {
-    if (!nome) return 'UN';
-    
-    return nome.split(" ").map(n => n[0]).join("").substring(0, 2).toUpperCase();
-  };
-
-  const formatCpf = (cpf: string) => {
-    if (!cpf) return '';
-    return cpf.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
-  };
-
-  const formatDate = (dateString: string | null) => {
-    if (!dateString) return '-';
-    return new Date(dateString).toLocaleDateString('pt-BR');
-  };
-
-  const generatePaedi = (beneficiaria: Beneficiaria) => {
-    try {
-      const dataCadastro = beneficiaria.data_criacao ? new Date(beneficiaria.data_criacao) : new Date();
-      const year = isNaN(dataCadastro.getTime()) ? new Date().getFullYear() : dataCadastro.getFullYear();
-      const sequence = beneficiaria.id.toString().padStart(3, '0').slice(-3);
-      return `MM-${year}-${sequence}`;
-    } catch (error) {
-      console.warn('Erro ao gerar PAEDI:', error);
-      const sequence = beneficiaria.id.toString().padStart(3, '0').slice(-3);
-      return `MM-${new Date().getFullYear()}-${sequence}`;
-    }
-  };
+  const showLoading = beneficiariasQuery.isLoading || beneficiariasQuery.isFetching;
+  const backendErrorMessage =
+    beneficiariasResponse && beneficiariasResponse.success === false
+      ? beneficiariasResponse.message
+      : undefined;
+  const queryError = beneficiariasQuery.isError
+    ? (beneficiariasQuery.error as Error | undefined)
+    : backendErrorMessage
+    ? new Error(backendErrorMessage)
+    : undefined;
+  const activeFilterCount =
+    (statusFilter !== 'Todas' ? 1 : 0) +
+    (programaFilter !== 'Todos' ? 1 : 0) +
+    (hasSearch ? 1 : 0);
 
   return (
     <div className="space-y-6">
@@ -212,25 +133,25 @@ export default function BeneficiariasFixed() {
       <div className="grid gap-4 md:grid-cols-4">
         <Card className="shadow-soft">
           <CardContent className="p-4">
-            <div className="text-2xl font-bold text-primary">{loading ? "..." : stats.total}</div>
+            <div className="text-2xl font-bold text-primary">{showLoading ? "..." : stats.total}</div>
             <p className="text-sm text-muted-foreground">Total de Beneficiárias</p>
           </CardContent>
         </Card>
         <Card className="shadow-soft">
           <CardContent className="p-4">
-            <div className="text-2xl font-bold text-success">{loading ? "..." : stats.ativas}</div>
+            <div className="text-2xl font-bold text-success">{showLoading ? "..." : stats.ativas}</div>
             <p className="text-sm text-muted-foreground">Ativas</p>
           </CardContent>
         </Card>
         <Card className="shadow-soft">
           <CardContent className="p-4">
-            <div className="text-2xl font-bold text-warning">{loading ? "..." : stats.aguardando}</div>
+            <div className="text-2xl font-bold text-warning">{showLoading ? "..." : stats.aguardando}</div>
             <p className="text-sm text-muted-foreground">Aguardando</p>
           </CardContent>
         </Card>
         <Card className="shadow-soft">
           <CardContent className="p-4">
-            <div className="text-2xl font-bold text-muted-foreground">{loading ? "..." : stats.inativas}</div>
+            <div className="text-2xl font-bold text-muted-foreground">{showLoading ? "..." : stats.inativas}</div>
             <p className="text-sm text-muted-foreground">Inativas</p>
           </CardContent>
         </Card>
@@ -242,6 +163,14 @@ export default function BeneficiariasFixed() {
           <CardTitle>Lista de Beneficiárias</CardTitle>
         </CardHeader>
         <CardContent>
+          {queryError && (
+            <Alert variant="destructive" className="mb-4" data-testid="beneficiarias-error">
+              <AlertTitle>Não foi possível carregar as beneficiárias</AlertTitle>
+              <AlertDescription>
+                {queryError.message || 'Ocorreu um erro ao carregar os dados. Tente novamente.'}
+              </AlertDescription>
+            </Alert>
+          )}
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between mb-6">
             <div className="flex flex-1 items-center gap-2">
               <div className="relative flex-1 max-w-sm">
@@ -249,7 +178,7 @@ export default function BeneficiariasFixed() {
                 <Input
                   placeholder="Buscar por nome, CPF ou PAEDI..."
                   value={searchTerm}
-                  onChange={(e) => setFilters({ search: e.target.value })}
+                  onChange={(e) => setFilters({ search: e.target.value, page: 1 })}
                   className="pl-10"
                   data-testid="search-input"
                 />
@@ -262,13 +191,18 @@ export default function BeneficiariasFixed() {
                 >
                   <Filter className="h-4 w-4" />
                 </Button>
-                {(() => { const c = (selectedStatus !== 'Todas' ? 1 : 0) + (programaFilter !== 'Todos' ? 1 : 0) + (searchTerm ? 1 : 0); return c ? (
-                  <span aria-label="Quantidade de filtros ativos" className="absolute -top-1 -right-1 h-5 min-w-[20px] px-1 rounded-full bg-primary text-primary-foreground text-xs flex items-center justify-center">{c}</span>
-                ) : null; })()}
+                {activeFilterCount > 0 ? (
+                  <span
+                    aria-label="Quantidade de filtros ativos"
+                    className="absolute -top-1 -right-1 h-5 min-w-[20px] px-1 rounded-full bg-primary text-primary-foreground text-xs flex items-center justify-center"
+                  >
+                    {activeFilterCount}
+                  </span>
+                ) : null}
               </div>
               <Button
                 variant="default"
-                onClick={() => setFilters({ search: searchTerm })}
+                onClick={() => setFilters({ search: searchTerm, page: 1 })}
                 data-testid="search-button"
               >
                 Buscar
@@ -288,20 +222,21 @@ export default function BeneficiariasFixed() {
                     <label className="text-sm font-medium mb-2 block">Status</label>
                     <select
                       value={selectedStatus}
-                      onChange={(e) => setFilters({ status: e.target.value })}
+                      onChange={(e) => setFilters({ status: e.target.value, page: 1 })}
                       className="w-full p-2 border rounded-md"
                     >
-                      <option value="Todas">Todas</option>
-                      <option value="Ativa">Ativa</option>
-                      <option value="Aguardando">Aguardando</option>
-                      <option value="Inativa">Inativa</option>
+                      {STATUS_OPTIONS.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
                     </select>
                   </div>
                   <div>
                     <label className="text-sm font-medium mb-2 block">Programa/Serviço</label>
                     <select
                       value={programaFilter}
-                      onChange={(e) => setFilters({ programa: e.target.value })}
+                      onChange={(e) => setFilters({ programa: e.target.value, page: 1 })}
                       className="w-full p-2 border rounded-md"
                     >
                       <option value="Todos">Todos</option>
@@ -311,8 +246,8 @@ export default function BeneficiariasFixed() {
                     </select>
                   </div>
                   <div className="flex items-end">
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       onClick={() => setFilters({ status: 'Todas', programa: 'Todos', search: '', page: 1 })}
                     >
                       Limpar Filtros
@@ -338,8 +273,8 @@ export default function BeneficiariasFixed() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {loading ? (
-                  <TableRow>
+                {showLoading ? (
+                  <TableRow data-testid="beneficiarias-loading">
                     <TableCell colSpan={7} className="py-4">
                       <ListSkeleton rows={6} columns={6} />
                     </TableCell>
@@ -362,7 +297,7 @@ export default function BeneficiariasFixed() {
                         <div className="flex items-center gap-3">
                           <Avatar className="h-8 w-8">
                             <AvatarFallback className="bg-primary text-primary-foreground text-xs">
-                              {getInitials(beneficiaria.nome_completo)}
+                              {getBeneficiariaInitials(beneficiaria.nome_completo)}
                             </AvatarFallback>
                           </Avatar>
                           <div>
@@ -371,17 +306,17 @@ export default function BeneficiariasFixed() {
                           </div>
                         </div>
                       </TableCell>
-                      <TableCell className="font-mono text-sm">{formatCpf(beneficiaria.cpf || '')}</TableCell>
+                      <TableCell className="font-mono text-sm">{formatCpf(beneficiaria.cpf)}</TableCell>
                       <TableCell className="font-mono text-sm font-medium text-primary">
                         {generatePaedi(beneficiaria)}
                       </TableCell>
                       <TableCell>{beneficiaria.telefone || beneficiaria.contato1 || 'Não informado'}</TableCell>
                       <TableCell>
-                        <Badge variant={getStatusVariant(getBeneficiariaStatus(beneficiaria))}>
-                          {getBeneficiariaStatus(beneficiaria)}
+                        <Badge variant={getBeneficiariaBadgeVariant(deriveBeneficiariaStatus(beneficiaria))}>
+                          {deriveBeneficiariaStatus(beneficiaria)}
                         </Badge>
                       </TableCell>
-                      <TableCell>{formatDate(beneficiaria.data_nascimento)}</TableCell>
+                      <TableCell>{formatBeneficiariaDate(beneficiaria.data_nascimento)}</TableCell>
                       <TableCell>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
@@ -413,28 +348,28 @@ export default function BeneficiariasFixed() {
           </div>
 
           {/* Pagination */}
-          {filteredBeneficiarias.length > itemsPerPage && (
+          {filteredBeneficiarias.length > ITEMS_PER_PAGE && (
             <div className="flex items-center justify-between pt-4">
               <div className="text-sm text-muted-foreground">
-                Mostrando {startIndex + 1} a {Math.min(endIndex, filteredBeneficiarias.length)} de {filteredBeneficiarias.length} beneficiárias
+                Mostrando {showingFrom} a {showingTo} de {filteredBeneficiarias.length} beneficiárias
               </div>
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setFilters({ page: currentPage - 1 })}
-                  disabled={currentPage === 1}
+                  onClick={() => setFilters({ page: safePage - 1 })}
+                  disabled={safePage === 1}
                 >
                   Anterior
                 </Button>
                 <span className="text-sm">
-                  Página {currentPage} de {totalPages}
+                  Página {safePage} de {totalPages}
                 </span>
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={() => setFilters({ page: currentPage + 1 })}
-                  disabled={currentPage === totalPages}
+                  onClick={() => setFilters({ page: safePage + 1 })}
+                  disabled={safePage === totalPages}
                 >
                   Próxima
                 </Button>

--- a/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
+++ b/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BeneficiariasFixed from '../BeneficiariasFixed';
+import * as beneficiariasHooks from '@/hooks/useBeneficiarias';
+
+vi.mock('@/hooks/useBeneficiarias', () => ({
+  useBeneficiarias: vi.fn(),
+  useBeneficiaria: vi.fn(),
+}));
+
+describe('BeneficiariasFixed page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
+      data: { success: true, data: [] },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+    });
+    (beneficiariasHooks.useBeneficiaria as unknown as Mock).mockReturnValue({});
+  });
+
+  it('renders loading skeleton when data is loading', () => {
+    (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: false,
+      isError: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <BeneficiariasFixed />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('beneficiarias-loading')).toBeInTheDocument();
+  });
+
+  it('displays error alert when loading fails', () => {
+    (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
+      data: { success: true, data: [] },
+      isLoading: false,
+      isError: true,
+      error: new Error('Falha ao listar'),
+      isFetching: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <BeneficiariasFixed />
+      </MemoryRouter>
+    );
+
+    const alert = screen.getByTestId('beneficiarias-error');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Falha ao listar');
+  });
+
+  it('displays backend error message when request succeeds with failure response', () => {
+    (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
+      data: { success: false, message: 'Erro remoto', data: [] },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <BeneficiariasFixed />
+      </MemoryRouter>
+    );
+
+    const alert = screen.getByTestId('beneficiarias-error');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Erro remoto');
+  });
+});

--- a/apps/frontend/src/pages/__tests__/OficinasNew.test.tsx
+++ b/apps/frontend/src/pages/__tests__/OficinasNew.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import OficinasNew from '../OficinasNew';
+import * as oficinasHooks from '@/hooks/useOficinas';
+import { useQuery } from '@tanstack/react-query';
+
+vi.mock('@/hooks/useOficinas', () => ({
+  useOficinas: vi.fn(),
+  useCreateOficina: vi.fn(),
+  useUpdateOficina: vi.fn(),
+  useDeleteOficina: vi.fn(),
+  useOficinaResumo: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(),
+}));
+
+describe('OficinasNew page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (oficinasHooks.useOficinas as unknown as Mock).mockReturnValue({
+      data: { success: true, data: [] },
+      isLoading: false,
+      isRefetching: false,
+      isError: false,
+    });
+    (oficinasHooks.useCreateOficina as unknown as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    (oficinasHooks.useUpdateOficina as unknown as Mock).mockReturnValue({ mutateAsync: vi.fn(), isPending: false });
+    (oficinasHooks.useDeleteOficina as unknown as Mock).mockReturnValue({ mutate: vi.fn() });
+    (oficinasHooks.useOficinaResumo as unknown as Mock).mockReturnValue({ data: { success: true, data: null }, isLoading: false, isError: false });
+
+    (useQuery as unknown as Mock).mockReturnValue({ data: { success: true, data: [] } });
+  });
+
+  it('renders loading placeholders while fetching', () => {
+    (oficinasHooks.useOficinas as unknown as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isRefetching: false,
+      isError: false,
+    });
+
+    const { container } = render(
+      <MemoryRouter>
+        <OficinasNew />
+      </MemoryRouter>
+    );
+
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('shows error alert when loading fails', () => {
+    (oficinasHooks.useOficinas as unknown as Mock).mockReturnValue({
+      data: { success: true, data: [] },
+      isLoading: false,
+      isError: true,
+      error: new Error('Erro de rede'),
+      isRefetching: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <OficinasNew />
+      </MemoryRouter>
+    );
+
+    const alert = screen.getByTestId('oficinas-error');
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent('Erro de rede');
+  });
+});

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { beneficiariaSchema } from '../validation/zodSchemas';
 import { apiService } from '@/services/apiService';
+import type {
+  BeneficiariaListResponse,
+  BeneficiariaResponse,
+  BeneficiariaResumoResponse,
+  ListBeneficiariasParams,
+} from '@/types/beneficiarias';
 
 type Beneficiaria = z.infer<typeof beneficiariaSchema>;
 
@@ -48,35 +54,55 @@ export const api = {
 
 // Serviços para beneficiárias delegando ao apiService
 export const beneficiariasService = {
-  listar: async (params?: { page?: number; limit?: number; search?: string; status?: string; escolaridade?: string; }) => {
-    const res = await apiService.getBeneficiarias(params);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao listar beneficiárias');
+  listar: async (params: ListBeneficiariasParams = {}): Promise<BeneficiariaListResponse> => {
+    const response = await apiService.getBeneficiarias(params);
+
+    if (!response.success) {
+      return {
+        ...response,
+        data: [],
+      } satisfies BeneficiariaListResponse;
+    }
+
+    const data = Array.isArray(response.data) ? response.data : [];
+
+    return {
+      ...response,
+      data,
+    } satisfies BeneficiariaListResponse;
   },
-  buscarPorId: async (id: string) => {
-    const res = await apiService.getBeneficiaria(id);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao buscar beneficiária');
+  buscarPorId: async (id: string): Promise<BeneficiariaResponse> => {
+    const response = await apiService.getBeneficiaria(id);
+
+    if (!response.success) {
+      return response as BeneficiariaResponse;
+    }
+
+    return {
+      ...response,
+      data: response.data,
+    } satisfies BeneficiariaResponse;
   },
-  buscarResumo: async (id: string) => {
-    const res = await apiService.get(`/beneficiarias/${id}/resumo`);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao buscar resumo');
+  buscarResumo: async (id: string): Promise<BeneficiariaResumoResponse> => {
+    const response = await apiService.get(`/beneficiarias/${id}/resumo`);
+
+    if (!response.success) {
+      return {
+        ...response,
+        data: undefined,
+      } satisfies BeneficiariaResumoResponse;
+    }
+
+    return response as BeneficiariaResumoResponse;
   },
   criar: async (beneficiaria: Omit<Beneficiaria, 'id'>) => {
-    const res = await apiService.createBeneficiaria(beneficiaria as any);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao criar beneficiária');
+    return apiService.createBeneficiaria(beneficiaria as any);
   },
   atualizar: async (id: string, beneficiaria: Partial<Beneficiaria>) => {
-    const res = await apiService.updateBeneficiaria(id, beneficiaria as any);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao atualizar beneficiária');
+    return apiService.updateBeneficiaria(id, beneficiaria as any);
   },
   excluir: async (id: string) => {
-    const res = await apiService.deleteBeneficiaria(id);
-    if (res.success) return res.data;
-    throw new Error(res.message || 'Erro ao excluir beneficiária');
+    return apiService.deleteBeneficiaria(id);
   },
 };
 

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -9,7 +9,6 @@ import type {
   AuthenticatedSessionUser,
   Beneficiaria,
   BeneficiariaFiltros,
-  Oficina,
 } from '@assist/types';
 import { translateErrorMessage } from '@/lib/apiError';
 import { API_URL } from '@/config';
@@ -26,6 +25,7 @@ import type {
   UpdateConfiguracoesPayload,
   UsuarioPermissions,
 } from '@/types/configuracoes';
+import type { Oficina } from '@/types/oficinas';
 const IS_DEV = (import.meta as any)?.env?.DEV === true || (import.meta as any)?.env?.MODE === 'development';
 
 type SessionUser = AuthenticatedSessionUser & { ativo?: boolean };
@@ -247,37 +247,37 @@ class ApiService {
     };
   }
 
-  async createOficina(data: any): Promise<ApiResponse<any>> {
+  async createOficina(data: any): Promise<ApiResponse<Oficina>> {
     return this.post<Oficina>('/oficinas', data);
   }
 
-  async updateOficina(id: string, data: any): Promise<ApiResponse<any>> {
+  async updateOficina(id: string, data: any): Promise<ApiResponse<Oficina>> {
     return this.put<Oficina>(`/oficinas/${id}`, data);
   }
 
-  async deleteOficina(id: string): Promise<ApiResponse<any>> {
+  async deleteOficina(id: string): Promise<ApiResponse<void>> {
     return this.delete<void>(`/oficinas/${id}`);
   }
 
   // Métodos específicos para beneficiárias
-  async getBeneficiarias(params?: any): Promise<ApiResponse<any[]>> {
-  return this.get<Beneficiaria[]>('/beneficiarias', { params });
+  async getBeneficiarias(params?: any): Promise<ApiResponse<Beneficiaria[]>> {
+    return this.get<Beneficiaria[]>('/beneficiarias', { params });
   }
 
-  async getBeneficiaria(id: string | number): Promise<ApiResponse<any>> {
-  return this.get<Beneficiaria>(`/beneficiarias/${id}`);
+  async getBeneficiaria(id: string | number): Promise<ApiResponse<Beneficiaria>> {
+    return this.get<Beneficiaria>(`/beneficiarias/${id}`);
   }
 
-  async createBeneficiaria(data: any): Promise<ApiResponse<any>> {
-  return this.post<Beneficiaria>('/beneficiarias', data);
+  async createBeneficiaria(data: any): Promise<ApiResponse<Beneficiaria>> {
+    return this.post<Beneficiaria>('/beneficiarias', data);
   }
 
-  async updateBeneficiaria(id: string, data: any): Promise<ApiResponse<any>> {
-  return this.put<Beneficiaria>(`/beneficiarias/${id}`, data);
+  async updateBeneficiaria(id: string, data: any): Promise<ApiResponse<Beneficiaria>> {
+    return this.put<Beneficiaria>(`/beneficiarias/${id}`, data);
   }
 
-  async deleteBeneficiaria(id: string): Promise<ApiResponse<any>> {
-  return this.delete<void>(`/beneficiarias/${id}`);
+  async deleteBeneficiaria(id: string): Promise<ApiResponse<void>> {
+    return this.delete<void>(`/beneficiarias/${id}`);
   }
 
   // Dashboard methods

--- a/apps/frontend/src/services/oficinas.service.ts
+++ b/apps/frontend/src/services/oficinas.service.ts
@@ -1,56 +1,13 @@
 import { api } from './api';
 import type { ApiResponse, Pagination } from '@/types/api';
-
-export interface Oficina {
-  id: number;
-  nome: string;
-  descricao?: string | null;
-  instrutor?: string | null;
-  data_inicio: string;
-  data_fim?: string | null;
-  horario_inicio: string;
-  horario_fim: string;
-  local?: string | null;
-  vagas_total: number;
-  vagas_ocupadas?: number;
-  status: 'ativa' | 'inativa' | 'pausada' | 'concluida';
-  dias_semana?: string;
-}
-
-export interface CreateOficinaDTO {
-  nome: string;
-  descricao?: string | null;
-  instrutor?: string | null;
-  data_inicio: string;
-  data_fim?: string | null;
-  horario_inicio: string;
-  horario_fim: string;
-  local?: string | null;
-  vagas_total: number;
-  dias_semana?: string;
-  projeto_id?: number;
-  status?: 'ativa' | 'inativa' | 'pausada' | 'concluida';
-}
-
-export interface UpdateOficinaDTO extends Partial<CreateOficinaDTO> {}
-
-export interface ListOficinasParams {
-  page?: number;
-  limit?: number;
-  search?: string;
-  status?: string;
-  projeto_id?: number;
-  data_inicio?: string;
-  data_fim?: string;
-  instrutor?: string;
-  sort?: keyof Oficina;
-  order?: 'asc' | 'desc';
-}
-
-export interface AddParticipanteDTO {
-  beneficiaria_id: number;
-  observacoes?: string;
-}
+import type {
+  AddParticipanteDTO,
+  CreateOficinaDTO,
+  ListOficinasParams,
+  Oficina,
+  OficinaResumo,
+  UpdateOficinaDTO,
+} from '@/types/oficinas';
 
 interface ListOficinasPayload {
   data: Oficina[];
@@ -61,7 +18,7 @@ export const OficinasService = {
   // Listar oficinas com filtros e paginação
   listar: async (params: ListOficinasParams = {}) => {
     const searchParams = new URLSearchParams();
-    
+
     Object.entries(params).forEach(([key, value]) => {
       if (value !== undefined) {
         searchParams.append(key, value.toString());
@@ -92,50 +49,50 @@ export const OficinasService = {
   },
 
   // Buscar oficina por ID
-  buscarPorId: async (id: number) => {
-    const response = await api.get(`/oficinas/${id}`);
+  buscarPorId: async (id: number): Promise<ApiResponse<Oficina>> => {
+    const response = await api.get<ApiResponse<Oficina>>(`/oficinas/${id}`);
     return response.data;
   },
 
   // Criar nova oficina
-  criar: async (data: CreateOficinaDTO) => {
-    const response = await api.post('/oficinas', data);
+  criar: async (data: CreateOficinaDTO): Promise<ApiResponse<Oficina>> => {
+    const response = await api.post<ApiResponse<Oficina>>('/oficinas', data);
     return response.data;
   },
 
   // Atualizar oficina existente
-  atualizar: async (id: number, data: UpdateOficinaDTO) => {
-    const response = await api.put(`/oficinas/${id}`, data);
+  atualizar: async (id: number, data: UpdateOficinaDTO): Promise<ApiResponse<Oficina>> => {
+    const response = await api.put<ApiResponse<Oficina>>(`/oficinas/${id}`, data);
     return response.data;
   },
 
   // Excluir oficina
-  excluir: async (id: number) => {
-    const response = await api.delete(`/oficinas/${id}`);
+  excluir: async (id: number): Promise<ApiResponse<void>> => {
+    const response = await api.delete<ApiResponse<void>>(`/oficinas/${id}`);
     return response.data;
   },
 
   // Adicionar participante à oficina
-  adicionarParticipante: async (id: number, data: AddParticipanteDTO) => {
-    const response = await api.post(`/oficinas/${id}/participantes`, data);
+  adicionarParticipante: async (id: number, data: AddParticipanteDTO): Promise<ApiResponse<void>> => {
+    const response = await api.post<ApiResponse<void>>(`/oficinas/${id}/participantes`, data);
     return response.data;
   },
 
   // Remover participante da oficina
-  removerParticipante: async (id: number, beneficiariaId: number) => {
-    const response = await api.delete(`/oficinas/${id}/participantes/${beneficiariaId}`);
+  removerParticipante: async (id: number, beneficiariaId: number): Promise<ApiResponse<void>> => {
+    const response = await api.delete<ApiResponse<void>>(`/oficinas/${id}/participantes/${beneficiariaId}`);
     return response.data;
   },
 
   // Listar participantes de uma oficina
-  listarParticipantes: async (id: number) => {
-    const response = await api.get(`/oficinas/${id}/participantes`);
+  listarParticipantes: async (id: number): Promise<ApiResponse<any>> => {
+    const response = await api.get<ApiResponse<any>>(`/oficinas/${id}/participantes`);
     return response.data;
   },
 
   // Marcar presença
   marcarPresenca: async (oficinaId: number, beneficiariaId: number, data: string, presente: boolean) => {
-    const response = await api.post(`/oficinas/${oficinaId}/presencas`, {
+    const response = await api.post<ApiResponse<void>>(`/oficinas/${oficinaId}/presencas`, {
       beneficiaria_id: beneficiariaId,
       data,
       presente
@@ -149,13 +106,13 @@ export const OficinasService = {
     if (data) {
       searchParams.append('data', data);
     }
-    const response = await api.get(`/oficinas/${id}/presencas?${searchParams.toString()}`);
+    const response = await api.get<ApiResponse<any>>(`/oficinas/${id}/presencas?${searchParams.toString()}`);
     return response.data;
   },
 
   // Buscar resumo da oficina (total de participantes, média de presença, etc)
-  buscarResumo: async (id: number) => {
-    const response = await api.get(`/oficinas/${id}/resumo`);
+  buscarResumo: async (id: number): Promise<ApiResponse<OficinaResumo>> => {
+    const response = await api.get<ApiResponse<OficinaResumo>>(`/oficinas/${id}/resumo`);
     return response.data;
   },
 

--- a/apps/frontend/src/types/beneficiarias.ts
+++ b/apps/frontend/src/types/beneficiarias.ts
@@ -1,0 +1,23 @@
+import type { ApiResponse } from '@/types/api';
+import type { Beneficiaria } from '@/types/shared';
+
+export interface ListBeneficiariasParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: Beneficiaria['status'];
+  escolaridade?: string;
+}
+
+export type BeneficiariaListResponse = ApiResponse<Beneficiaria[]>;
+
+export type BeneficiariaResponse = ApiResponse<Beneficiaria>;
+
+export interface BeneficiariaResumo {
+  total_oficinas?: number;
+  total_atendimentos?: number;
+  ultima_atualizacao?: string | null;
+  [key: string]: unknown;
+}
+
+export type BeneficiariaResumoResponse = ApiResponse<BeneficiariaResumo>;

--- a/apps/frontend/src/types/oficinas.ts
+++ b/apps/frontend/src/types/oficinas.ts
@@ -1,0 +1,85 @@
+import type { ApiResponse, Pagination } from '@/types/api';
+
+export type OficinaStatus = 'ativa' | 'inativa' | 'pausada' | 'concluida';
+
+export interface Oficina {
+  id: number;
+  nome: string;
+  descricao?: string | null;
+  instrutor?: string | null;
+  data_inicio: string;
+  data_fim?: string | null;
+  horario_inicio: string;
+  horario_fim: string;
+  local?: string | null;
+  vagas_total: number;
+  vagas_ocupadas?: number | null;
+  status: OficinaStatus;
+  dias_semana?: string | null;
+  projeto_id?: number | null;
+  projeto_nome?: string | null;
+  responsavel_id?: number | null;
+  responsavel_nome?: string | null;
+  total_participantes?: number | null;
+  data_criacao?: string;
+  data_atualizacao?: string;
+}
+
+export interface OficinaResumo {
+  total_participantes?: number;
+  taxa_ocupacao?: number;
+  presenca_media?: number;
+  encontros_realizados?: number;
+  proximo_encontro?: string | null;
+}
+
+export interface CreateOficinaDTO {
+  nome: string;
+  descricao?: string | null;
+  instrutor?: string | null;
+  data_inicio: string;
+  data_fim?: string | null;
+  horario_inicio: string;
+  horario_fim: string;
+  local?: string | null;
+  vagas_total: number;
+  dias_semana?: string | null;
+  projeto_id?: number | null;
+  status?: OficinaStatus;
+}
+
+export interface UpdateOficinaDTO extends Partial<CreateOficinaDTO> {}
+
+export interface ListOficinasParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  status?: OficinaStatus | string;
+  projeto_id?: number;
+  data_inicio?: string;
+  data_fim?: string;
+  instrutor?: string;
+  sort?: keyof Oficina;
+  order?: 'asc' | 'desc';
+}
+
+export type OficinasApiResponse = ApiResponse<Oficina[]> & {
+  pagination?: Pagination & { totalPages?: number };
+};
+
+export interface OficinaResumoResponse extends ApiResponse<OficinaResumo> {}
+
+export interface OficinaFormValues {
+  nome: string;
+  descricao: string;
+  instrutor: string;
+  data_inicio: string;
+  data_fim: string;
+  horario_inicio: string;
+  horario_fim: string;
+  local: string;
+  vagas_total: number;
+  status: OficinaStatus;
+  projeto_id: string;
+  dias_semana: string;
+}

--- a/apps/frontend/src/utils/beneficiarias.ts
+++ b/apps/frontend/src/utils/beneficiarias.ts
@@ -1,0 +1,166 @@
+import type { Beneficiaria } from '@/types/shared';
+import {
+  formatarCPF,
+  statusBeneficiariaDisplay,
+  stripNonDigits,
+  formatDateLocale,
+} from '@/utils/formatters';
+
+export type BeneficiariaStatusDisplay = 'Ativa' | 'Inativa' | 'Aguardando' | 'Desistente';
+
+export interface BeneficiariasFilters {
+  search?: string;
+  status?: BeneficiariaStatusDisplay | 'Todas';
+  programa?: string;
+}
+
+export interface BeneficiariasStats {
+  total: number;
+  ativas: number;
+  aguardando: number;
+  inativas: number;
+  desistentes: number;
+}
+
+const statusDisplayMap: Record<Beneficiaria['status'], BeneficiariaStatusDisplay> = {
+  ativa: 'Ativa',
+  inativa: 'Inativa',
+  pendente: 'Aguardando',
+  desistente: 'Desistente',
+};
+
+const badgeVariants: Record<BeneficiariaStatusDisplay, 'default' | 'secondary' | 'outline'> = {
+  Ativa: 'default',
+  Aguardando: 'secondary',
+  Inativa: 'outline',
+  Desistente: 'secondary',
+};
+
+const fallbackStatusFromActiveFlag = (ativo?: boolean | null): BeneficiariaStatusDisplay => {
+  if (ativo === false) return 'Inativa';
+  return 'Ativa';
+};
+
+export const deriveBeneficiariaStatus = (
+  beneficiaria: Partial<Beneficiaria> & { ativo?: boolean | null; status?: string | null }
+): BeneficiariaStatusDisplay => {
+  if (beneficiaria.status && statusDisplayMap[beneficiaria.status as Beneficiaria['status']]) {
+    return statusDisplayMap[beneficiaria.status as Beneficiaria['status']];
+  }
+
+  const normalized = (beneficiaria.status || '').toLowerCase();
+  if (normalized in statusDisplayMap) {
+    return statusDisplayMap[normalized as Beneficiaria['status']];
+  }
+
+  return fallbackStatusFromActiveFlag(beneficiaria.ativo);
+};
+
+export const getBeneficiariaBadgeVariant = (
+  status: BeneficiariaStatusDisplay
+): 'default' | 'secondary' | 'outline' => badgeVariants[status] ?? 'default';
+
+export const getBeneficiariaInitials = (nome?: string | null): string => {
+  if (!nome) return 'UN';
+  return nome
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+};
+
+export const formatCpf = (cpf?: string | null): string => {
+  if (!cpf) return '';
+  return formatarCPF(cpf);
+};
+
+export const formatBeneficiariaDate = (dateString?: string | null): string => {
+  return formatDateLocale(dateString, 'pt-BR');
+};
+
+export const generatePaedi = (
+  beneficiaria: Pick<Beneficiaria, 'id'> & { data_criacao?: string | null; created_at?: string | null }
+): string => {
+  const isoDate = beneficiaria.data_criacao || beneficiaria.created_at;
+  const createdAt = isoDate ? new Date(isoDate) : new Date();
+  const year = Number.isNaN(createdAt.getTime()) ? new Date().getFullYear() : createdAt.getFullYear();
+  const sequence = beneficiaria.id.toString().padStart(3, '0').slice(-3);
+  return `MM-${year}-${sequence}`;
+};
+
+export const normalizeBeneficiariaSearch = (search?: string) => {
+  const raw = search ?? '';
+  const normalized = raw.trim().toLowerCase();
+  const numeric = stripNonDigits(raw);
+  return {
+    normalized,
+    numeric,
+    hasSearch: normalized.length > 0 || numeric.length > 0,
+  };
+};
+
+export const filterBeneficiarias = (
+  beneficiarias: Beneficiaria[],
+  filters: BeneficiariasFilters
+): Beneficiaria[] => {
+  const { normalized, numeric, hasSearch } = normalizeBeneficiariaSearch(filters.search);
+  const statusFilter = filters.status ?? 'Todas';
+  const programaFilter = filters.programa ?? 'Todos';
+
+  return beneficiarias.filter((beneficiaria) => {
+    const nome = beneficiaria.nome_completo?.toLowerCase() ?? '';
+    const cpfNumbers = stripNonDigits(beneficiaria.cpf ?? '');
+    const paedi = generatePaedi(beneficiaria).toLowerCase();
+    const statusDisplay = deriveBeneficiariaStatus(beneficiaria);
+
+    const matchesSearch =
+      !hasSearch ||
+      nome.includes(normalized) ||
+      (numeric.length > 0 && cpfNumbers.includes(numeric)) ||
+      paedi.includes(normalized);
+
+    const matchesStatus = statusFilter === 'Todas' || statusDisplay === statusFilter;
+    const matchesPrograma = programaFilter === 'Todos' || !filters.programa;
+
+    return matchesSearch && matchesStatus && matchesPrograma;
+  });
+};
+
+export const buildBeneficiariasStats = (beneficiarias: Beneficiaria[]): BeneficiariasStats => {
+  return beneficiarias.reduce<BeneficiariasStats>(
+    (acc, beneficiaria) => {
+      const status = deriveBeneficiariaStatus(beneficiaria);
+
+      if (status === 'Ativa') acc.ativas += 1;
+      if (status === 'Aguardando') acc.aguardando += 1;
+      if (status === 'Inativa') acc.inativas += 1;
+      if (status === 'Desistente') acc.desistentes += 1;
+
+      acc.total += 1;
+      return acc;
+    },
+    { total: 0, ativas: 0, aguardando: 0, inativas: 0, desistentes: 0 }
+  );
+};
+
+export const toStatusFilterValue = (display: string): Beneficiaria['status'] | undefined => {
+  const normalized = display.toLowerCase();
+  if (normalized === 'todas') return undefined;
+
+  const entries = Object.entries(statusDisplayMap) as Array<[
+    Beneficiaria['status'],
+    BeneficiariaStatusDisplay
+  ]>;
+
+  const match = entries.find(([, label]) => label.toLowerCase() === normalized);
+  return match?.[0];
+};
+
+export const getStatusDisplay = (status: Beneficiaria['status']): BeneficiariaStatusDisplay => {
+  const label = statusBeneficiariaDisplay(status) as BeneficiariaStatusDisplay | string;
+  return (['Ativa', 'Inativa', 'Aguardando', 'Desistente'].includes(label)
+    ? (label as BeneficiariaStatusDisplay)
+    : statusDisplayMap[status]) ?? 'Ativa';
+};

--- a/apps/frontend/src/utils/formatters.ts
+++ b/apps/frontend/src/utils/formatters.ts
@@ -79,6 +79,21 @@ export const statusBeneficiariaDisplay = (status: Beneficiaria['status']): strin
     return displays[status] ?? status;
 };
 
+export const stripNonDigits = (value: string): string => value.replace(/\D/g, '');
+
+export const formatDateLocale = (
+    dateString?: string | null,
+    locale: string = 'pt-BR',
+    fallback: string = '-'
+): string => {
+    if (!dateString) return fallback;
+    const parsed = new Date(dateString);
+    if (Number.isNaN(parsed.getTime())) {
+        return fallback;
+    }
+    return parsed.toLocaleDateString(locale);
+};
+
 export const estadoCivilDisplay = (estadoCivil: Beneficiaria['estado_civil']): string => {
     if (!estadoCivil) return '';
     const displays: Record<string, string> = {

--- a/apps/frontend/src/utils/oficinas.ts
+++ b/apps/frontend/src/utils/oficinas.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod';
+import type {
+  CreateOficinaDTO,
+  Oficina,
+  OficinaFormValues,
+  OficinaResumo,
+  OficinaStatus,
+} from '@/types/oficinas';
+
+const statusEnum = z.enum(['ativa', 'inativa', 'pausada', 'concluida']);
+
+const oficinaFormSchema = z.object({
+  nome: z.string().trim().min(1, 'Por favor, informe o nome da oficina'),
+  descricao: z.string().optional(),
+  instrutor: z.string().optional(),
+  data_inicio: z.string().min(1, 'Informe a data de início'),
+  data_fim: z.string().optional(),
+  horario_inicio: z.string().min(1, 'Informe o horário de início'),
+  horario_fim: z.string().min(1, 'Informe o horário de fim'),
+  local: z.string().optional(),
+  vagas_total: z.coerce.number().int().positive('O número de vagas deve ser maior que zero'),
+  status: statusEnum,
+  projeto_id: z.union([z.string(), z.number()]).optional().default('none'),
+  dias_semana: z.string().optional(),
+});
+
+export type OficinaValidationResult =
+  | { success: true; payload: CreateOficinaDTO }
+  | { success: false; message: string };
+
+const normalizeOptional = (value?: string | null) => {
+  if (value === undefined) return undefined;
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+};
+
+const parseProjetoId = (value?: string | number): number | undefined => {
+  if (value === undefined || value === null) return undefined;
+  if (value === '' || value === 'none') return undefined;
+  const numeric = Number(value);
+  return Number.isNaN(numeric) ? undefined : numeric;
+};
+
+export const validateAndNormalizeOficina = (
+  formValues: OficinaFormValues
+): OficinaValidationResult => {
+  const result = oficinaFormSchema.safeParse(formValues);
+
+  if (!result.success) {
+    const firstError = result.error.errors[0]?.message ?? 'Dados inválidos';
+    return { success: false, message: firstError };
+  }
+
+  const values = result.data;
+
+  if (values.horario_inicio >= values.horario_fim) {
+    return {
+      success: false,
+      message: 'O horário de início deve ser anterior ao horário de fim',
+    };
+  }
+
+  if (values.data_fim && values.data_inicio > values.data_fim) {
+    return {
+      success: false,
+      message: 'A data de início deve ser anterior à data de fim',
+    };
+  }
+
+  const payload: CreateOficinaDTO = {
+    nome: values.nome,
+    descricao: normalizeOptional(values.descricao) ?? null,
+    instrutor: normalizeOptional(values.instrutor) ?? null,
+    data_inicio: values.data_inicio,
+    data_fim: normalizeOptional(values.data_fim) ?? null,
+    horario_inicio: values.horario_inicio,
+    horario_fim: values.horario_fim,
+    local: normalizeOptional(values.local) ?? null,
+    vagas_total: values.vagas_total,
+    dias_semana: normalizeOptional(values.dias_semana) ?? null,
+    status: values.status,
+  };
+
+  const projetoId = parseProjetoId(values.projeto_id);
+  if (projetoId !== undefined) {
+    payload.projeto_id = projetoId;
+  }
+
+  return { success: true, payload };
+};
+
+export const formatDateForInput = (isoDate?: string | null): string => {
+  if (!isoDate) return '';
+  const [datePart] = isoDate.split('T');
+  return datePart ?? '';
+};
+
+export const mapOficinaToFormValues = (oficina: Oficina): OficinaFormValues => ({
+  nome: oficina.nome,
+  descricao: oficina.descricao ?? '',
+  instrutor: oficina.instrutor ?? '',
+  data_inicio: formatDateForInput(oficina.data_inicio),
+  data_fim: formatDateForInput(oficina.data_fim ?? undefined),
+  horario_inicio: oficina.horario_inicio,
+  horario_fim: oficina.horario_fim,
+  local: oficina.local ?? '',
+  vagas_total: oficina.vagas_total,
+  status: oficina.status,
+  projeto_id: oficina.projeto_id ? oficina.projeto_id.toString() : 'none',
+  dias_semana: oficina.dias_semana ?? '',
+});
+
+export const getOficinaStatusMetadata = (
+  status: OficinaStatus,
+  vagasTotal: number,
+  vagasOcupadas?: number | null
+): { badgeClass: string; label: string } => {
+  const ocupadas = vagasOcupadas ?? 0;
+
+  if (status === 'inativa' || status === 'pausada') {
+    return { badgeClass: 'bg-red-100 text-red-800', label: status === 'inativa' ? 'Inativa' : 'Pausada' };
+  }
+
+  if (status === 'concluida') {
+    return { badgeClass: 'bg-primary/10 text-primary', label: 'Concluída' };
+  }
+
+  if (status === 'ativa' && ocupadas >= vagasTotal) {
+    return { badgeClass: 'bg-orange-100 text-orange-800', label: 'Lotada' };
+  }
+
+  return { badgeClass: 'bg-green-100 text-green-800', label: 'Ativa' };
+};
+
+export const getVagasDisponiveis = (vagasTotal: number, vagasOcupadas?: number | null): number => {
+  return Math.max(0, vagasTotal - (vagasOcupadas ?? 0));
+};
+
+export const resumoIndicators = (resumo?: OficinaResumo | null) => {
+  if (!resumo) return [] as Array<{ label: string; value: string }>;
+  const indicators: Array<{ label: string; value: string }> = [];
+
+  if (typeof resumo.total_participantes === 'number') {
+    indicators.push({ label: 'Participantes', value: resumo.total_participantes.toString() });
+  }
+  if (typeof resumo.taxa_ocupacao === 'number') {
+    indicators.push({ label: 'Ocupação', value: `${Math.round(resumo.taxa_ocupacao * 100)}%` });
+  }
+  if (typeof resumo.presenca_media === 'number') {
+    indicators.push({ label: 'Presença média', value: `${Math.round(resumo.presenca_media * 100)}%` });
+  }
+  if (typeof resumo.encontros_realizados === 'number') {
+    indicators.push({ label: 'Encontros', value: resumo.encontros_realizados.toString() });
+  }
+  if (resumo.proximo_encontro) {
+    indicators.push({ label: 'Próximo encontro', value: resumo.proximo_encontro });
+  }
+
+  return indicators;
+};
+
+export const initialOficinaFormValues: OficinaFormValues = {
+  nome: '',
+  descricao: '',
+  instrutor: '',
+  data_inicio: '',
+  data_fim: '',
+  horario_inicio: '',
+  horario_fim: '',
+  local: '',
+  vagas_total: 20,
+  status: 'ativa',
+  projeto_id: 'none',
+  dias_semana: '',
+};
+
+export const normalizeResumoDate = (resumo?: OficinaResumo | null): OficinaResumo | null => {
+  if (!resumo) return null;
+  if (!resumo.proximo_encontro) return resumo;
+  return {
+    ...resumo,
+    proximo_encontro: formatDateForInput(resumo.proximo_encontro),
+  };
+};
+
+export { oficinaFormSchema };


### PR DESCRIPTION
## Summary
- refactor BeneficiariasFixed to rely on typed beneficiarias hooks and shared helpers for filtering, stats, and formatting
- align OficinasNew with the typed oficinas hooks and improve resumo indicators plus backend error reporting
- add shared beneficiarias API types and extend the page tests to cover loading and failure states

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d8624692ac8324be6a14db167b5278