### PR TITLE
Allow CSRF header through CORS and document toggle

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -52,11 +52,19 @@ const corsOriginOption = (() => {
   return true;
 })();
 
+const defaultAllowedHeaders: string[] = ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-Token'];
+const additionalAllowedHeaders = env.CORS_ALLOWED_HEADERS
+  ?.split(',')
+  .map((header) => header.trim())
+  .filter((header) => header.length > 0);
+
+const allowedHeaders = Array.from(new Set([...(defaultAllowedHeaders || []), ...(additionalAllowedHeaders || [])]));
+
 const corsOptions = {
   origin: corsOriginOption,
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization'],
+  allowedHeaders,
 };
 app.use(cors(corsOptions));
 

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -57,6 +57,7 @@ const envSchema = z.object({
   RATE_LIMIT_DISABLE: booleanFromEnv.default(false),
   ENABLE_WS: booleanFromEnv.default(false),
   CORS_ORIGIN: z.string().optional(),
+  CORS_ALLOWED_HEADERS: z.string().optional(),
   POSTGRES_HOST: z.string().min(1, 'POSTGRES_HOST é obrigatório'),
   POSTGRES_PORT: z.coerce.number().default(5432),
   POSTGRES_DB: z.string().min(1, 'POSTGRES_DB é obrigatório'),

--- a/apps/frontend/src/config/index.ts
+++ b/apps/frontend/src/config/index.ts
@@ -11,4 +11,6 @@ const API_URL =
   import.meta.env.VITE_API_URL ||
   (ENV === 'development' ? '/api' : 'http://localhost:3000/api');
 
-export { API_URL, AUTH_TOKEN_KEY, USER_KEY };
+const REQUIRE_CSRF_HEADER = String(import.meta.env.VITE_REQUIRE_CSRF_HEADER ?? 'true').toLowerCase() !== 'false';
+
+export { API_URL, AUTH_TOKEN_KEY, USER_KEY, REQUIRE_CSRF_HEADER };

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -11,7 +11,7 @@ import type {
   BeneficiariaFiltros,
 } from '@assist/types';
 import { translateErrorMessage } from '@/lib/apiError';
-import { API_URL } from '@/config';
+import { API_URL, REQUIRE_CSRF_HEADER } from '@/config';
 import type { DashboardStatsResponse } from '@/types/dashboard';
 import type { ApiResponse, Pagination } from '@/types/api';
 import type {
@@ -68,9 +68,13 @@ class ApiService {
         }
 
         // CSRF header opcional (se o backend validar)
-        const csrf = getCookie('csrf_token');
-        if (csrf && config.method && ['post','put','patch','delete'].includes(config.method)) {
-          (config.headers as any)['X-CSRF-Token'] = csrf;
+        if (REQUIRE_CSRF_HEADER) {
+          const csrf = getCookie('csrf_token');
+          if (csrf && config.method && ['post', 'put', 'patch', 'delete'].includes(config.method)) {
+            (config.headers as any)['X-CSRF-Token'] = csrf;
+          }
+        } else if (config.headers && 'X-CSRF-Token' in config.headers) {
+          delete (config.headers as any)['X-CSRF-Token'];
         }
 
         if (IS_DEV) {

--- a/docs/SECURITY_MIGRATION_COOKIES.md
+++ b/docs/SECURITY_MIGRATION_COOKIES.md
@@ -5,7 +5,7 @@ Este guia descreve como operar a autenticação com cookies HttpOnly e proteçã
 ## Estado Atual
 
 - Login já define cookie HttpOnly `auth_token` (ver `apps/backend/src/routes/auth.routes.ts`).
-- O cliente (`src/services/apiService.ts`) envia `withCredentials: true` e, se existir cookie `csrf_token`, envia `X-CSRF-Token` automaticamente.
+- O cliente (`src/services/apiService.ts`) envia `withCredentials: true` e, se existir cookie `csrf_token`, envia `X-CSRF-Token` automaticamente. Defina `VITE_REQUIRE_CSRF_HEADER=false` para desativar esse cabeçalho enquanto o backend não exigir validação.
 - Autorização no backend funciona com cookie `auth_token` ou `Authorization: Bearer` como fallback.
 
 ## Passos Recomendados
@@ -13,6 +13,7 @@ Este guia descreve como operar a autenticação com cookies HttpOnly e proteçã
 1. Habilitar CORS com credenciais
 
 - Em `apps/backend/src/app.ts` CORS já está ativo. Garanta `credentials: true` e `origin` com a lista de domínios confiáveis (sem `*` em produção).
+- Quando precisar liberar cabeçalhos adicionais (ex.: `X-CSRF-Token`, `X-Requested-With` ou outros específicos do proxy), configure `CORS_ALLOWED_HEADERS` com uma lista separada por vírgulas.
 
 2. Provisionar CSRF Token (cookie + header)
 


### PR DESCRIPTION
## Summary
- allow X-CSRF-Token and additional custom headers via updated CORS configuration and env parsing
- add a frontend toggle to conditionally emit the CSRF header and document the new behaviour in the security migration guide

## Testing
- curl -i -X OPTIONS http://localhost:4010/health -H "Origin: http://localhost:5173" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: X-CSRF-Token"

------
https://chatgpt.com/codex/tasks/task_e_68d95bad92f88324ba76c47e32f83bc1