### PR TITLE
feat(frontend): restrict sidebar menu by role

### DIFF
--- a/apps/frontend/src/components/layout/__tests__/sidebar.test.tsx
+++ b/apps/frontend/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Sidebar from '../sidebar';
+
+const mockUseAuth = vi.fn();
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth()
+}));
+
+describe('Sidebar permissions', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  const renderSidebar = () =>
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+
+  it('renders admin-only items when the user is admin', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, nome: 'Admin', papel: 'admin' },
+      isAdmin: true
+    });
+
+    renderSidebar();
+
+    expect(screen.getByTestId('menu-relatorios')).toBeInTheDocument();
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Configurações')).toBeInTheDocument();
+  });
+
+  it('hides admin-only items for collaborators', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, nome: 'Colaboradora', papel: 'user' },
+      isAdmin: false
+    });
+
+    renderSidebar();
+
+    expect(screen.getByTestId('menu-dashboard')).toBeInTheDocument();
+    expect(screen.queryByTestId('menu-relatorios')).not.toBeInTheDocument();
+    expect(screen.queryByText('Analytics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Configurações')).not.toBeInTheDocument();
+    expect(screen.getByText('Feed')).toBeInTheDocument();
+    expect(screen.queryByText('Novo Cadastro')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { 
-  Users, 
-  FileText, 
+import {
+  Users,
+  FileText,
   Heart, 
   BarChart3, 
   Settings, 
@@ -21,73 +21,174 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
+import type { LucideIcon } from "lucide-react";
 
-const menuItems = [
+type Role = "guest" | "user" | "admin" | "super_admin" | "superadmin";
+
+interface MenuChildItem {
+  title: string;
+  href: string;
+  allowedRoles: Role[];
+}
+
+interface MenuItem {
+  title: string;
+  icon: LucideIcon;
+  href?: string;
+  children?: MenuChildItem[];
+  allowedRoles: Role[];
+}
+
+const ADMIN_ROLES: Role[] = ["admin", "super_admin", "superadmin"];
+const STAFF_ROLES: Role[] = ["user", ...ADMIN_ROLES];
+
+const roleAliases: Record<string, Role> = {
+  admin: "admin",
+  super_admin: "super_admin",
+  superadmin: "superadmin",
+  user: "user",
+  colaborador: "user",
+  colaboradora: "user",
+  collaborator: "user",
+  colaborator: "user"
+};
+
+const normalizeRole = (role?: string | null): Role => {
+  if (!role) return "guest";
+  const normalized = role.toLowerCase();
+  if (roleAliases[normalized]) {
+    return roleAliases[normalized];
+  }
+
+  const knownRoles: Role[] = ["guest", "user", "admin", "super_admin", "superadmin"];
+  return knownRoles.includes(normalized as Role) ? (normalized as Role) : "guest";
+};
+
+const menuItems: MenuItem[] = [
   {
-    title: "Dashboard", 
+    title: "Dashboard",
     icon: Home,
-    href: "/dashboard"
+    href: "/dashboard",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Beneficiárias",
     icon: Users,
-    href: "/beneficiarias"
+    href: "/beneficiarias",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Novo Cadastro",
     icon: UserPlus,
-    href: "/beneficiarias/nova"
+    href: "/beneficiarias/nova",
+    allowedRoles: ADMIN_ROLES
   },
   {
     title: "Oficinas",
     icon: GraduationCap,
-    href: "/oficinas"
+    href: "/oficinas",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Projetos",
     icon: FolderKanban,
-    href: "/projetos"
+    href: "/projetos",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Feed",
     icon: Heart,
-    href: "/feed"
+    href: "/feed",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Chat Interno",
     icon: MessageSquare,
-    href: "/chat-interno"
+    href: "/chat-interno",
+    allowedRoles: STAFF_ROLES
   },
   {
     title: "Formulários",
     icon: FileText,
+    allowedRoles: STAFF_ROLES,
     children: [
-      { title: "Declarações e Recibos", href: "/declaracoes-recibos" },
-      { title: "Anamnese Social", href: "/formularios/anamnese" },
-      { title: "Ficha de Evolução", href: "/formularios/evolucao" },
-      { title: "Termo de Consentimento", href: "/formularios/termo" },
-      { title: "Visão Holística", href: "/formularios/visao" },
-      { title: "Roda da Vida", href: "/formularios/roda-vida" },
-      { title: "Plano de Ação", href: "/formularios/plano" },
-      { title: "Matrícula de Projetos", href: "/formularios/matricula" }
+      { title: "Declarações e Recibos", href: "/declaracoes-recibos", allowedRoles: STAFF_ROLES },
+      { title: "Anamnese Social", href: "/formularios/anamnese", allowedRoles: STAFF_ROLES },
+      { title: "Ficha de Evolução", href: "/formularios/evolucao", allowedRoles: STAFF_ROLES },
+      { title: "Termo de Consentimento", href: "/formularios/termo", allowedRoles: STAFF_ROLES },
+      { title: "Visão Holística", href: "/formularios/visao", allowedRoles: STAFF_ROLES },
+      { title: "Roda da Vida", href: "/formularios/roda-vida", allowedRoles: STAFF_ROLES },
+      { title: "Plano de Ação", href: "/formularios/plano", allowedRoles: STAFF_ROLES },
+      { title: "Matrícula de Projetos", href: "/formularios/matricula", allowedRoles: STAFF_ROLES }
     ]
   },
   {
     title: "Relatórios",
     icon: BarChart3,
-    href: "/relatorios"
+    href: "/relatorios",
+    allowedRoles: ADMIN_ROLES
   },
   {
     title: "Analytics",
     icon: TrendingUp,
-    href: "/analytics"
+    href: "/analytics",
+    allowedRoles: ADMIN_ROLES
   }
 ];
+
+const settingsItem: MenuItem = {
+  title: "Configurações",
+  icon: Settings,
+  href: "/configuracoes",
+  allowedRoles: ADMIN_ROLES
+};
+
+const filterMenuItems = (
+  items: MenuItem[],
+  hasAccess: (roles: Role[]) => boolean
+): MenuItem[] =>
+  items.reduce<MenuItem[]>((acc, item) => {
+    if (!hasAccess(item.allowedRoles)) {
+      return acc;
+    }
+
+    if (item.children) {
+      const allowedChildren = item.children.filter(child => hasAccess(child.allowedRoles));
+      if (allowedChildren.length === 0) {
+        return acc;
+      }
+      acc.push({ ...item, children: allowedChildren });
+      return acc;
+    }
+
+    acc.push(item);
+    return acc;
+  }, []);
 
 export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedItems, setExpandedItems] = useState<string[]>(["Formulários"]);
   const location = useLocation();
+  const { user, isAdmin } = useAuth();
+
+  const userRole = useMemo(() => normalizeRole(user?.papel), [user?.papel]);
+
+  const hasAccess = useCallback(
+    (roles: Role[]) => {
+      if (roles.includes("guest")) return true;
+      if (isAdmin) return true;
+      return roles.includes(userRole);
+    },
+    [isAdmin, userRole]
+  );
+
+  const availableMenuItems = useMemo(
+    () => filterMenuItems(menuItems, hasAccess),
+    [hasAccess]
+  );
+
+  const canViewSettings = hasAccess(settingsItem.allowedRoles);
 
   const toggleExpanded = (title: string) => {
     setExpandedItems(prev => 
@@ -143,7 +244,7 @@ export default function Sidebar() {
 
           {/* Navigation */}
           <nav className="flex-1 p-4 space-y-2 overflow-y-auto">
-            {menuItems.map((item) => (
+            {availableMenuItems.map((item) => (
               <div key={item.title}>
                 {item.children ? (
                   <div>
@@ -210,21 +311,23 @@ export default function Sidebar() {
           </nav>
 
           {/* Footer */}
-          <div className="p-4 border-t border-sidebar-border">
-            <NavLink
-              to="/configuracoes"
-              className={({ isActive }) => cn(
-                "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                isActive 
-                  ? "bg-primary text-primary-foreground shadow-soft" 
-                  : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              )}
-              onClick={() => setIsOpen(false)}
-            >
-              <Settings className="h-4 w-4" />
-              Configurações
-            </NavLink>
-          </div>
+          {canViewSettings && (
+            <div className="p-4 border-t border-sidebar-border">
+              <NavLink
+                to={settingsItem.href!}
+                className={({ isActive }) => cn(
+                  "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-soft"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+                onClick={() => setIsOpen(false)}
+              >
+                <settingsItem.icon className="h-4 w-4" />
+                {settingsItem.title}
+              </NavLink>
+            </div>
+          )}
         </div>
       </aside>
     </>


### PR DESCRIPTION
## Summary
- add role metadata to each sidebar menu entry and filter options by the authenticated role
- hide the configuration link for collaborators while keeping admin items visible for privileged roles
- add sidebar tests covering both admin and collaborator scenarios

## Testing
- npx vitest run src/components/layout/__tests__/sidebar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d95bac7ecc8324b2bbbf073f6b81b5