### PR TITLE
feat: add SQL job queue migration and integration test

### DIFF
--- a/apps/backend/src/__tests__/job-queue.integration.test.ts
+++ b/apps/backend/src/__tests__/job-queue.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from '@jest/globals';
+import type { Pool } from 'pg';
+import {
+  setupTestDatabase,
+  teardownTestDatabase,
+  truncateAllTables
+} from './helpers/database';
+
+const runIntegration = process.env.RUN_INTEGRATION === '1';
+let pool: Pool;
+
+async function createQueueService() {
+  if (!runIntegration) {
+    throw new Error('Integration tests desabilitados');
+  }
+
+  jest.resetModules();
+
+  jest.doMock('../config/database', () => ({
+    pool,
+    db: {
+      query: async (text: string, params?: any[]) => {
+        const result = await pool.query(text, params);
+        return result.rows;
+      }
+    }
+  }));
+
+  jest.doMock('../services/logger', () => ({
+    logger: {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn()
+    }
+  }));
+
+  const module = await import('../services/QueueService');
+  return new module.QueueService();
+}
+
+describe('QueueService job queue (integration)', () => {
+  beforeAll(async () => {
+    if (!runIntegration) return;
+    const db = await setupTestDatabase();
+    pool = db.pool;
+  });
+
+  afterEach(async () => {
+    if (!runIntegration) return;
+    await truncateAllTables();
+  });
+
+  afterAll(async () => {
+    if (!runIntegration) return;
+    await teardownTestDatabase();
+  });
+
+  it('enqueues, processes and cleans up jobs', async () => {
+    if (!runIntegration) return;
+
+    const queueService = await createQueueService();
+
+    const { id } = await queueService.enqueue('cleanup_data', { olderThanDays: 1 });
+
+    const persisted = await pool.query('SELECT * FROM job_queue WHERE id = $1', [id]);
+    expect(persisted.rowCount).toBe(1);
+    expect(persisted.rows[0].status).toBe('pending');
+
+    const jobRow = persisted.rows[0];
+    await (queueService as any).runJob({
+      id: jobRow.id,
+      job_type: jobRow.job_type,
+      payload: jobRow.payload,
+      tentativas: jobRow.tentativas,
+      max_tentativas: jobRow.max_tentativas
+    });
+
+    const completed = await pool.query(
+      'SELECT status, executed_at FROM job_queue WHERE id = $1',
+      [id]
+    );
+    expect(completed.rows[0].status).toBe('completed');
+    expect(completed.rows[0].executed_at).not.toBeNull();
+
+    await pool.query(
+      `UPDATE job_queue
+         SET status = 'completed',
+             executed_at = NOW() - interval '40 days',
+             updated_at = NOW() - interval '40 days'
+       WHERE id = $1`,
+      [id]
+    );
+
+    await queueService.cleanupOldJobs();
+
+    const remaining = await pool.query('SELECT 1 FROM job_queue WHERE id = $1', [id]);
+    expect(remaining.rowCount).toBe(0);
+  });
+});

--- a/apps/backend/src/database/migrations/048_criar_job_queue.sql
+++ b/apps/backend/src/database/migrations/048_criar_job_queue.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS job_queue (
+    id BIGSERIAL PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    prioridade INTEGER NOT NULL DEFAULT 1,
+    status TEXT NOT NULL DEFAULT 'pending',
+    tentativas INTEGER NOT NULL DEFAULT 0,
+    max_tentativas INTEGER NOT NULL DEFAULT 3,
+    last_error TEXT,
+    locked_at TIMESTAMPTZ,
+    locked_by TEXT,
+    scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    executed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_queue_status_prioridade
+    ON job_queue (status, prioridade DESC, scheduled_at);
+
+CREATE INDEX IF NOT EXISTS idx_job_queue_pending_scheduled
+    ON job_queue (scheduled_at)
+    WHERE status = 'pending';
+
+CREATE OR REPLACE FUNCTION set_job_queue_updated_at()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_job_queue_set_updated_at ON job_queue;
+CREATE TRIGGER trg_job_queue_set_updated_at
+    BEFORE UPDATE ON job_queue
+    FOR EACH ROW
+    EXECUTE FUNCTION set_job_queue_updated_at();
+
+CREATE OR REPLACE FUNCTION cleanup_old_jobs(retention_days INTEGER DEFAULT 30)
+RETURNS INTEGER AS
+$$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    WITH deleted AS (
+        DELETE FROM job_queue
+        WHERE status IN ('completed', 'failed', 'cancelled')
+          AND COALESCE(executed_at, updated_at, created_at) < NOW() - (retention_days || ' days')::interval
+        RETURNING 1
+    )
+    SELECT COUNT(*) INTO deleted_count FROM deleted;
+
+    RETURN COALESCE(deleted_count, 0);
+END;
+$$ LANGUAGE plpgsql;

--- a/apps/backend/src/services/QueueService.ts
+++ b/apps/backend/src/services/QueueService.ts
@@ -1,5 +1,4 @@
 import { db } from '../database';
-import { redis } from '../lib/redis';
 import { logger } from '../services/logger';
 import { NotificationJob } from '../jobs/NotificationJob';
 import { ReminderJob } from '../jobs/ReminderJob';


### PR DESCRIPTION
## Summary
- add a SQL migration that provisions the job_queue table, indexes, and cleanup helpers
- drop the unused Redis import from QueueService to avoid requiring Redis when it is disabled
- cover the enqueue/process/cleanup flow with an integration test backed by the real migrations

## Testing
- RUN_INTEGRATION=1 npx jest src/__tests__/job-queue.integration.test.ts -c jest.integration.config.js *(fails: TypeError: ansiRegex is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68d95bb10ea4832499291b7eaa4c1133