### PR TITLE
Normalize beneficiaria list data and refactor hook consumers

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useApi.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useApi.test.tsx
@@ -67,7 +67,7 @@ describe('useApi hooks', () => {
     });
 
     expect(apiService.getBeneficiarias).toHaveBeenCalledWith(params);
-    expect(result.current.data).toEqual({ data: [{ id: 1 }], pagination });
+    expect(result.current.data).toEqual({ items: [{ id: 1 }], pagination });
   });
 
   it('deve retornar array de dados e sem paginação quando a resposta for simples', async () => {
@@ -84,7 +84,7 @@ describe('useApi hooks', () => {
     });
 
     expect(apiService.getBeneficiarias).toHaveBeenCalledWith(undefined);
-    expect(result.current.data).toEqual({ data: [{ id: 1 }, { id: 2 }], pagination: undefined });
+    expect(result.current.data).toEqual({ items: [{ id: 1 }, { id: 2 }], pagination: undefined });
   });
 
   it('deve enviar o filtro correto ao buscar participações', async () => {

--- a/apps/frontend/src/hooks/__tests__/useBeneficiarias.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useBeneficiarias.test.ts
@@ -7,7 +7,7 @@ import { createQueryClientWrapper } from './testUtils';
 beforeEach(() => {
   vi.spyOn(beneficiariasService, 'listar').mockResolvedValue({
     success: true,
-    data: [],
+    data: { items: [], pagination: undefined },
   });
 });
 

--- a/apps/frontend/src/hooks/useApi.ts
+++ b/apps/frontend/src/hooks/useApi.ts
@@ -8,7 +8,7 @@ import { beneficiariaSchema } from '../validation/zodSchemas';
 type Beneficiaria = z.infer<typeof beneficiariaSchema>;
 
 // Hooks para beneficiárias
-type BeneficiariasQueryResult = { data: Beneficiaria[]; pagination?: Pagination };
+type BeneficiariasQueryResult = { items: Beneficiaria[]; pagination?: Pagination };
 
 export const useBeneficiarias = (params?: { page?: number; limit?: number }) => {
   const queryKey = ['beneficiarias', params] as const;
@@ -22,7 +22,7 @@ export const useBeneficiarias = (params?: { page?: number; limit?: number }) => 
       }
 
       const payload = response.data;
-      const data = Array.isArray(payload)
+      const items = Array.isArray(payload)
         ? payload
         : Array.isArray((payload as any)?.data)
           ? (payload as any).data
@@ -32,7 +32,7 @@ export const useBeneficiarias = (params?: { page?: number; limit?: number }) => 
         || response.pagination;
 
       return {
-        data,
+        items,
         pagination,
       };
     },

--- a/apps/frontend/src/hooks/useBeneficiarias.ts
+++ b/apps/frontend/src/hooks/useBeneficiarias.ts
@@ -9,6 +9,20 @@ import type {
 } from '@/types/beneficiarias';
 import { toast } from 'sonner';
 
+const normalizeListResponse = (response: BeneficiariaListResponse): BeneficiariaListResponse => {
+  const items = response.data?.items ?? [];
+  const pagination = response.data?.pagination ?? response.pagination;
+
+  return {
+    ...response,
+    data: {
+      items,
+      pagination,
+    },
+    pagination,
+  } satisfies BeneficiariaListResponse;
+};
+
 // Keys para React Query
 export const beneficiariasKeys = {
   all: ['beneficiarias'] as const,
@@ -19,11 +33,11 @@ export const beneficiariasKeys = {
 };
 
 // Hook para listar beneficiárias
-// ...existing code...
 export const useBeneficiarias = (params: ListBeneficiariasParams = {}): UseQueryResult<BeneficiariaListResponse> => {
-  return useQuery<BeneficiariaListResponse>({
+  return useQuery<BeneficiariaListResponse, Error, BeneficiariaListResponse>({
     queryKey: beneficiariasKeys.list(params),
     queryFn: () => beneficiariasService.listar(params),
+    select: normalizeListResponse,
   });
 };
 

--- a/apps/frontend/src/pages/BeneficiariasFixed.tsx
+++ b/apps/frontend/src/pages/BeneficiariasFixed.tsx
@@ -71,8 +71,7 @@ export default function BeneficiariasFixed() {
   const beneficiariasResponse = beneficiariasQuery.data;
   const beneficiarias: Beneficiaria[] = useMemo(() => {
     if (beneficiariasResponse?.success === false) return [];
-    const data = beneficiariasResponse?.data;
-    return Array.isArray(data) ? data : [];
+    return (beneficiariasResponse?.data?.items ?? []) as Beneficiaria[];
   }, [beneficiariasResponse]);
 
   const firstBeneficiariaId = beneficiarias.length > 0 ? String(beneficiarias[0].id) : '';

--- a/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
+++ b/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
@@ -13,7 +13,7 @@ describe('BeneficiariasFixed page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: true, data: [] },
+      data: { success: true, data: { items: [], pagination: undefined } },
       isLoading: false,
       isFetching: false,
       isError: false,
@@ -40,7 +40,7 @@ describe('BeneficiariasFixed page', () => {
 
   it('displays error alert when loading fails', () => {
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: true, data: [] },
+      data: { success: true, data: { items: [], pagination: undefined } },
       isLoading: false,
       isError: true,
       error: new Error('Falha ao listar'),
@@ -60,7 +60,7 @@ describe('BeneficiariasFixed page', () => {
 
   it('displays backend error message when request succeeds with failure response', () => {
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: false, message: 'Erro remoto', data: [] },
+      data: { success: false, message: 'Erro remoto', data: { items: [], pagination: undefined } },
       isLoading: false,
       isError: false,
       isFetching: false,

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -57,18 +57,21 @@ export const beneficiariasService = {
   listar: async (params: ListBeneficiariasParams = {}): Promise<BeneficiariaListResponse> => {
     const response = await apiService.getBeneficiarias(params);
 
-    if (!response.success) {
-      return {
-        ...response,
-        data: [],
-      } satisfies BeneficiariaListResponse;
-    }
-
-    const data = Array.isArray(response.data) ? response.data : [];
+    const payload = response.data;
+    const items = Array.isArray(payload)
+      ? payload
+      : Array.isArray((payload as any)?.data)
+        ? (payload as any).data
+        : [];
+    const pagination = (!Array.isArray(payload) && (payload as any)?.pagination) ?? response.pagination;
 
     return {
       ...response,
-      data,
+      data: {
+        items,
+        pagination,
+      },
+      pagination,
     } satisfies BeneficiariaListResponse;
   },
   buscarPorId: async (id: string): Promise<BeneficiariaResponse> => {

--- a/apps/frontend/src/types/beneficiarias.ts
+++ b/apps/frontend/src/types/beneficiarias.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse } from '@/types/api';
+import type { ApiResponse, Pagination } from '@/types/api';
 import type { Beneficiaria } from '@/types/shared';
 
 export interface ListBeneficiariasParams {
@@ -9,7 +9,12 @@ export interface ListBeneficiariasParams {
   escolaridade?: string;
 }
 
-export type BeneficiariaListResponse = ApiResponse<Beneficiaria[]>;
+export interface BeneficiariaListData {
+  items: Beneficiaria[];
+  pagination?: Pagination;
+}
+
+export type BeneficiariaListResponse = ApiResponse<BeneficiariaListData>;
 
 export type BeneficiariaResponse = ApiResponse<Beneficiaria>;
 


### PR DESCRIPTION
## Summary
- normalize the beneficiaria list types/service to expose items and pagination consistently
- update React Query hooks and the Beneficiarias page to consume the normalized payload and reuse central data loading
- refresh dependent components and tests, including DeclaracoesReciboGeral and BeneficiariasFixed, for the new list shape

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d95baa2f108324b95a62b5ea548165