### PR TITLE
Restrict admin-only frontend routes

### DIFF
--- a/apps/frontend/src/components/layout/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar.tsx
@@ -1,28 +1,40 @@
 import { useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
-import { 
-  Users, 
-  FileText, 
-  Heart, 
-  BarChart3, 
-  Settings, 
+import {
+  Users,
+  FileText,
+  Heart,
+  BarChart3,
+  Settings,
   Menu,
   X,
   Home,
   UserPlus,
   ClipboardList,
-  FileCheck,
-  Eye,
-  Target,
   GraduationCap,
   TrendingUp,
   FolderKanban,
-  MessageSquare
+  MessageSquare,
+  type LucideIcon
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 
-const menuItems = [
+type MenuChild = {
+  title: string;
+  href: string;
+};
+
+type MenuItem = {
+  title: string;
+  icon: LucideIcon;
+  href?: string;
+  children?: MenuChild[];
+  adminOnly?: boolean;
+};
+
+const menuItems: MenuItem[] = [
   {
     title: "Dashboard", 
     icon: Home,
@@ -75,12 +87,14 @@ const menuItems = [
   {
     title: "Relatórios",
     icon: BarChart3,
-    href: "/relatorios"
+    href: "/relatorios",
+    adminOnly: true
   },
   {
     title: "Analytics",
     icon: TrendingUp,
-    href: "/analytics"
+    href: "/analytics",
+    adminOnly: true
   }
 ];
 
@@ -88,6 +102,7 @@ export default function Sidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedItems, setExpandedItems] = useState<string[]>(["Formulários"]);
   const location = useLocation();
+  const { isAdmin } = useAuth();
 
   const toggleExpanded = (title: string) => {
     setExpandedItems(prev => 
@@ -144,7 +159,8 @@ export default function Sidebar() {
           {/* Navigation */}
           <nav className="flex-1 p-4 space-y-2 overflow-y-auto">
             {menuItems.map((item) => (
-              <div key={item.title}>
+              item.adminOnly && !isAdmin ? null : (
+                <div key={item.title}>
                 {item.children ? (
                   <div>
                     <Button
@@ -205,26 +221,29 @@ export default function Sidebar() {
                     {item.title}
                   </NavLink>
                 )}
-              </div>
+                </div>
+              )
             ))}
           </nav>
 
           {/* Footer */}
-          <div className="p-4 border-t border-sidebar-border">
-            <NavLink
-              to="/configuracoes"
-              className={({ isActive }) => cn(
-                "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
-                isActive 
-                  ? "bg-primary text-primary-foreground shadow-soft" 
-                  : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-              )}
-              onClick={() => setIsOpen(false)}
-            >
-              <Settings className="h-4 w-4" />
-              Configurações
-            </NavLink>
-          </div>
+          {isAdmin && (
+            <div className="p-4 border-t border-sidebar-border">
+              <NavLink
+                to="/configuracoes"
+                className={({ isActive }) => cn(
+                  "flex items-center gap-2 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground shadow-soft"
+                    : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+                onClick={() => setIsOpen(false)}
+              >
+                <Settings className="h-4 w-4" />
+                Configurações
+              </NavLink>
+            </div>
+          )}
         </div>
       </aside>
     </>

--- a/apps/frontend/src/routes/__tests__/restricted-routes.test.tsx
+++ b/apps/frontend/src/routes/__tests__/restricted-routes.test.tsx
@@ -1,0 +1,129 @@
+import { type ReactNode } from 'react';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { MemoryRouter, Routes, Route, Outlet } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+const mockUseAuth = vi.fn();
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth()
+}));
+
+vi.mock('@/pages/Analytics', () => ({
+  default: () => <div>Analytics Page</div>
+}));
+
+vi.mock('@/pages/Configuracoes', () => ({
+  default: () => <div>Config Page</div>
+}));
+
+const renderWithRoute = (initialEntry: string, routes: ReactNode) => {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/" element={<Outlet />}>
+          <Route index element={<div>Home Page</div>} />
+          {routes}
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('Restricted routes', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+  });
+
+  it('redirects non-admin users away from analytics', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, nome: 'Usuário', papel: 'user' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: false
+    });
+
+    renderWithRoute(
+      '/analytics',
+      <Route
+        path="analytics"
+        element={(
+          <ProtectedRoute adminOnly>
+            <div>Analytics Page</div>
+          </ProtectedRoute>
+        )}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Home Page')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Analytics Page')).not.toBeInTheDocument();
+  });
+
+  it('redirects non-admin users away from configuration pages', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, nome: 'Usuário', papel: 'user' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: false
+    });
+
+    renderWithRoute(
+      '/configuracoes',
+      <Route
+        path="configuracoes"
+        element={(
+          <ProtectedRoute adminOnly>
+            <Outlet />
+          </ProtectedRoute>
+        )}
+      >
+        <Route index element={<div>Config Page</div>} />
+      </Route>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Home Page')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Config Page')).not.toBeInTheDocument();
+  });
+
+  it('allows admin users to access analytics', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 3, nome: 'Admin', papel: 'admin' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: true
+    });
+
+    renderWithRoute(
+      '/analytics',
+      <Route
+        path="analytics"
+        element={(
+          <ProtectedRoute adminOnly>
+            <div>Analytics Page</div>
+          </ProtectedRoute>
+        )}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Analytics Page')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/routes/features.routes.tsx
+++ b/apps/frontend/src/routes/features.routes.tsx
@@ -1,5 +1,6 @@
 import { lazy } from "react";
 import { Route } from "react-router-dom";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 // Lazy loaded components
 const Analytics = lazy(() => import("@/pages/Analytics"));
@@ -15,7 +16,14 @@ const NotificationsPage = lazy(() => import("@/pages/Notifications"));
 
 export const FeaturesRoutes = () => (
   <>
-    <Route path="analytics" element={<Analytics />} />
+    <Route
+      path="analytics"
+      element={(
+        <ProtectedRoute adminOnly>
+          <Analytics />
+        </ProtectedRoute>
+      )}
+    />
     <Route path="oficinas" element={<OficinasNew />} />
     <Route path="participantes" element={<ParticipantesIndisponivel />} />
     <Route path="chat-interno" element={<ChatInterno />} />
@@ -23,7 +31,14 @@ export const FeaturesRoutes = () => (
     <Route path="calendar" element={<CalendarPage />} />
     <Route path="feed" element={<FeedNew />} />
     <Route path="projetos" element={<ProjetosNew />} />
-    <Route path="relatorios" element={<Relatorios />} />
+    <Route
+      path="relatorios"
+      element={(
+        <ProtectedRoute adminOnly>
+          <Relatorios />
+        </ProtectedRoute>
+      )}
+    />
     <Route path="notifications" element={<NotificationsPage />} />
   </>
 );

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -1,9 +1,10 @@
 import { lazy } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, Outlet } from "react-router-dom";
 import { BeneficiariasRoutes } from "./beneficiarias.routes";
 import { FormulariosRoutes } from "./formularios.routes";
 import { FeaturesRoutes } from "./features.routes";
 import { ProtectedLayoutOutlet } from "@/components/layout/ProtectedLayoutOutlet";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 // Lazy loaded pages
 const Index = lazy(() => import("@/pages/Index"));
@@ -13,6 +14,20 @@ const NotFound = lazy(() => import("@/pages/NotFound"));
 const Configuracoes = lazy(() => import("@/pages/Configuracoes"));
 const EditarPerfil = lazy(() => import("@/components/EditarPerfil"));
 const DeclaracoesReciboGeral = lazy(() => import("@/pages/DeclaracoesReciboGeral"));
+
+export const ConfiguracoesRoute = () => (
+  <Route
+    path="configuracoes"
+    element={(
+      <ProtectedRoute adminOnly>
+        <Outlet />
+      </ProtectedRoute>
+    )}
+  >
+    <Route index element={<Configuracoes />} />
+    <Route path="perfil" element={<EditarPerfil />} />
+  </Route>
+);
 
 export const AppRoutes = () => (
   <Routes>
@@ -31,10 +46,7 @@ export const AppRoutes = () => (
       <FeaturesRoutes />
 
       {/* Configurações */}
-      <Route path="configuracoes">
-        <Route index element={<Configuracoes />} />
-        <Route path="perfil" element={<EditarPerfil />} />
-      </Route>
+      <ConfiguracoesRoute />
 
       {/* Declarações e Recibos */}
       <Route path="declaracoes-recibos" element={<DeclaracoesReciboGeral />} />


### PR DESCRIPTION
## Summary
- wrap analytics, relatórios, and configurações routes with the shared ProtectedRoute admin guard
- hide admin-only links in the sidebar when the current user lacks privileges
- add routing tests that assert non-admin profiles are redirected away from protected pages

## Testing
- npx vitest run src/routes/__tests__/restricted-routes.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d95bcc2ca883249fa8639302fa273e