### PR TITLE
Standardize frontend auth token storage

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useApi.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useApi.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, vi, describe, it, expect } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { createElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { apiService } from '@/services/apiService';
 import useApi, { useBeneficiarias, useCreateParticipacao, useParticipacoes, useUpdateParticipacao } from '../useApi';
@@ -17,9 +17,8 @@ const createWrapper = () => {
     },
   });
 
-  const wrapper = ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient, children });
 
   return { wrapper, queryClient };
 };

--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   type ReactNode,
 } from "react";
+import { AUTH_TOKEN_KEY, USER_KEY } from "@/config";
 import { AuthService } from "@/services/auth.service";
 
 interface User {
@@ -58,7 +59,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     const handleStorageEvent = (event: StorageEvent) => {
-      const relevantKeys = new Set(["token", "auth_token", "user"]);
+      const relevantKeys = new Set([
+        "token",
+        "auth_token",
+        AUTH_TOKEN_KEY,
+        "user",
+        USER_KEY
+      ]);
       if (event.key === null || relevantKeys.has(event.key)) {
         handleLogoutEvent();
       }
@@ -81,11 +88,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       type LoginResponse = { token?: string; user?: User };
       const resp = response as LoginResponse;
       if (resp.token) {
-        localStorage.setItem('auth_token', resp.token);
-        localStorage.setItem('token', resp.token);
+        localStorage.setItem(AUTH_TOKEN_KEY, resp.token);
+        // Limpar chaves legadas
+        if (AUTH_TOKEN_KEY !== 'auth_token') {
+          localStorage.removeItem('auth_token');
+        }
+        if (AUTH_TOKEN_KEY !== 'token') {
+          localStorage.removeItem('token');
+        }
       }
       if (resp.user) {
-        localStorage.setItem('user', JSON.stringify(resp.user));
+        localStorage.setItem(USER_KEY, JSON.stringify(resp.user));
+        if (USER_KEY !== 'user') {
+          localStorage.removeItem('user');
+        }
         setUser(resp.user);
       }
       return {};
@@ -101,8 +117,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       await authService.logout();
     } finally {
-      localStorage.removeItem("auth_token");
-      localStorage.removeItem("user");
+      const tokenKeys = new Set([
+        'token',
+        'auth_token',
+        AUTH_TOKEN_KEY
+      ]);
+      tokenKeys.forEach((key) => localStorage.removeItem(key));
+      localStorage.removeItem('user');
+      localStorage.removeItem(USER_KEY);
       setUser(null);
       setLoading(false);
     }

--- a/apps/frontend/src/hooks/useSocket.ts
+++ b/apps/frontend/src/hooks/useSocket.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { io, Socket } from "socket.io-client";
+import { AUTH_TOKEN_KEY } from "@/config";
 import { useAuth } from "./useAuth";
 
 interface Message {
@@ -40,9 +41,8 @@ const useSocket = (socketUrl?: string) => {
       return;
     }
 
-    // Obter token do localStorage
-    // O app salva o JWT com a chave 'token' (ver usePostgreSQLAuth.tsx)
-    const token = localStorage.getItem('token');
+    // Obter token do localStorage (compatibilidade com chaves antigas)
+    const token = localStorage.getItem(AUTH_TOKEN_KEY) || localStorage.getItem('token');
     if (!token) {
       console.warn('Token não encontrado');
       return;

--- a/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
+++ b/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { FileText, Download, Search, Users } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
+import { AUTH_TOKEN_KEY } from "@/config";
 import apiService from "@/services/apiService";
 import { downloadDeclaracao, downloadRecibo } from "@/utils/pdfDownload";
 
@@ -132,7 +133,10 @@ export default function DeclaracoesReciboGeral() {
         // Fazer download do PDF usando utilitário
         const declaracaoId = (response.data as any)?.declaracao?.id;
         if (declaracaoId) {
-          const token = localStorage.getItem('token') || '';
+          const token =
+            localStorage.getItem(AUTH_TOKEN_KEY) ||
+            localStorage.getItem('token') ||
+            '';
           const downloadOk = await downloadDeclaracao(declaracaoId, token);
           
           if (!downloadOk) {
@@ -201,7 +205,10 @@ export default function DeclaracoesReciboGeral() {
         // Fazer download do PDF usando utilitário
         const reciboId = (response.data as any)?.recibo?.id;
         if (reciboId) {
-          const token = localStorage.getItem('token') || '';
+          const token =
+            localStorage.getItem(AUTH_TOKEN_KEY) ||
+            localStorage.getItem('token') ||
+            '';
           const downloadOk = await downloadRecibo(reciboId, token);
           
           if (!downloadOk) {

--- a/apps/frontend/src/pages/formularios/DeclaracoesRecibos.tsx
+++ b/apps/frontend/src/pages/formularios/DeclaracoesRecibos.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ArrowLeft, FileText, Download, Calendar, User, Award, Receipt, CheckCircle } from 'lucide-react';
+import { AUTH_TOKEN_KEY } from '@/config';
 import { apiService } from '@/services/apiService';
 import { downloadDeclaracao, downloadRecibo } from '@/utils/pdfDownload';
 
@@ -95,7 +96,10 @@ export default function DeclaracoesRecibos() {
         // Fazer download do PDF usando utilitário
         const declaracaoId = (response.data as any)?.declaracao?.id;
         if (declaracaoId) {
-          const token = localStorage.getItem('token') || '';
+          const token =
+            localStorage.getItem(AUTH_TOKEN_KEY) ||
+            localStorage.getItem('token') ||
+            '';
           const downloadOk = await downloadDeclaracao(declaracaoId, token);
           
           if (!downloadOk) {
@@ -133,7 +137,10 @@ export default function DeclaracoesRecibos() {
         // Fazer download do PDF usando utilitário
         const reciboId = (response.data as any)?.recibo?.id;
         if (reciboId) {
-          const token = localStorage.getItem('token') || '';
+          const token =
+            localStorage.getItem(AUTH_TOKEN_KEY) ||
+            localStorage.getItem('token') ||
+            '';
           const downloadOk = await downloadRecibo(reciboId, token);
           
           if (!downloadOk) {

--- a/apps/frontend/src/services/apiService.test.ts
+++ b/apps/frontend/src/services/apiService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { AUTH_TOKEN_KEY } from '@/config';
 import apiService from './apiService';
 
 describe('apiService', () => {
@@ -14,5 +15,21 @@ describe('apiService', () => {
     const res = await apiService.get('/rota-simulada');
     expect(res.success).toBe(true);
     expect(res.data).toEqual({ ok: true });
+  });
+
+  it('não envia Authorization após limpar tokens', async () => {
+    const handlers = (apiService as any).api.interceptors.request.handlers;
+    const requestHandler = handlers.find((handler: any) => handler && typeof handler.fulfilled === 'function');
+    expect(requestHandler).toBeDefined();
+
+    const handlerFn = requestHandler!.fulfilled;
+
+    localStorage.setItem(AUTH_TOKEN_KEY, 'meu-token');
+    const withToken = await handlerFn({ headers: {} });
+    expect(withToken.headers.Authorization).toBe('Bearer meu-token');
+
+    localStorage.clear();
+    const withoutToken = await handlerFn({ headers: { Authorization: 'Bearer antigo' } });
+    expect(withoutToken.headers.Authorization).toBeUndefined();
   });
 });

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -11,7 +11,7 @@ import type {
   BeneficiariaFiltros,
 } from '@assist/types';
 import { translateErrorMessage } from '@/lib/apiError';
-import { API_URL } from '@/config';
+import { API_URL, AUTH_TOKEN_KEY, USER_KEY } from '@/config';
 import type { DashboardStatsResponse } from '@/types/dashboard';
 import type { ApiResponse, Pagination } from '@/types/api';
 import type {
@@ -60,7 +60,10 @@ class ApiService {
     // Interceptor para adicionar token em todas as requisições
     this.api.interceptors.request.use(
       (config) => {
-        const token = localStorage.getItem('token') || localStorage.getItem('auth_token');
+        const token =
+          localStorage.getItem(AUTH_TOKEN_KEY) ||
+          localStorage.getItem('auth_token') ||
+          localStorage.getItem('token');
         if (token && token !== 'undefined') {
           config.headers.Authorization = `Bearer ${token}`;
         } else if (config.headers && 'Authorization' in config.headers) {
@@ -110,8 +113,14 @@ class ApiService {
         
         // Tratar erro de autenticação
         if (error.response && error.response.status === 401) {
-          localStorage.removeItem('token');
+          const tokenKeys = new Set([
+            'token',
+            'auth_token',
+            AUTH_TOKEN_KEY
+          ]);
+          tokenKeys.forEach((key) => localStorage.removeItem(key));
           localStorage.removeItem('user');
+          localStorage.removeItem(USER_KEY);
           // HashRouter-safe redirect
           if (typeof window !== 'undefined') {
             window.dispatchEvent(new Event('auth:logout'));

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -1,3 +1,4 @@
+import { AUTH_TOKEN_KEY, USER_KEY } from '@/config';
 import api from '@/config/api';
 import axios from 'axios';
 
@@ -45,8 +46,14 @@ export class AuthService {
     try {
       await api.post('/auth/logout', undefined, { withCredentials: true });
       // Limpar token e dados do usuário localmente
-      localStorage.removeItem('auth_token');
+      const tokenKeys = new Set([
+        'token',
+        'auth_token',
+        AUTH_TOKEN_KEY
+      ]);
+      tokenKeys.forEach((key) => localStorage.removeItem(key));
       localStorage.removeItem('user');
+      localStorage.removeItem(USER_KEY);
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     }
@@ -62,16 +69,16 @@ export class AuthService {
   }
 
   isAuthenticated(): boolean {
-    const token = localStorage.getItem('auth_token');
+    const token = localStorage.getItem(AUTH_TOKEN_KEY) || localStorage.getItem('auth_token') || localStorage.getItem('token');
     return !!token;
   }
 
   getToken(): string | null {
-    return localStorage.getItem('auth_token');
+    return localStorage.getItem(AUTH_TOKEN_KEY) || localStorage.getItem('auth_token') || localStorage.getItem('token');
   }
 
   getUser(): AuthResponse['user'] | null {
-    const userStr = localStorage.getItem('user');
+    const userStr = localStorage.getItem(USER_KEY) || localStorage.getItem('user');
     return userStr ? JSON.parse(userStr) : null;
   }
 }


### PR DESCRIPTION
## Summary
- update the auth provider, AuthService, and API service to rely on the configured token and user storage keys and clear legacy entries on logout
- align auxiliary hooks and download flows with the new token key handling to avoid stale Authorization headers
- add a regression test ensuring the API interceptor removes Authorization headers once tokens are cleared and tweak the useApi test wrapper to avoid JSX parsing issues

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d95ba8dbe483248862906924a11160