### PR TITLE
Normalize beneficiarias list response

### DIFF
--- a/apps/frontend/src/pages/BeneficiariasFixed.tsx
+++ b/apps/frontend/src/pages/BeneficiariasFixed.tsx
@@ -69,10 +69,13 @@ export default function BeneficiariasFixed() {
 
   const beneficiariasQuery = useBeneficiarias(queryFilters);
   const beneficiariasResponse = beneficiariasQuery.data;
+  const beneficiariasPagination = beneficiariasResponse?.data?.pagination;
   const beneficiarias: Beneficiaria[] = useMemo(() => {
     if (beneficiariasResponse?.success === false) return [];
     const data = beneficiariasResponse?.data;
-    return Array.isArray(data) ? data : [];
+    if (!data) return [];
+    if (Array.isArray((data as any)?.items)) return (data as any).items as Beneficiaria[];
+    return Array.isArray(data) ? (data as Beneficiaria[]) : [];
   }, [beneficiariasResponse]);
 
   const firstBeneficiariaId = beneficiarias.length > 0 ? String(beneficiarias[0].id) : '';
@@ -90,7 +93,10 @@ export default function BeneficiariasFixed() {
     [beneficiarias, programaFilter, searchTerm, statusFilter]
   );
 
-  const totalPages = Math.max(1, Math.ceil(filteredBeneficiarias.length / ITEMS_PER_PAGE));
+  const totalPages = Math.max(
+    1,
+    beneficiariasPagination?.totalPages ?? Math.ceil(filteredBeneficiarias.length / ITEMS_PER_PAGE)
+  );
   const safePage = Math.min(Math.max(currentPage, 1), totalPages);
   const startIndex = (safePage - 1) * ITEMS_PER_PAGE;
   const endIndex = startIndex + ITEMS_PER_PAGE;

--- a/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
+++ b/apps/frontend/src/pages/DeclaracoesReciboGeral.tsx
@@ -81,7 +81,8 @@ export default function DeclaracoesReciboGeral() {
     try {
       const response = await apiService.getBeneficiarias();
       if (response.success && response.data) {
-        setBeneficiarias(response.data);
+        const { items = [] } = response.data;
+        setBeneficiarias(items);
       }
     } catch (error) {
       console.error('Erro ao carregar beneficiárias:', error);

--- a/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
+++ b/apps/frontend/src/pages/__tests__/BeneficiariasFixed.test.tsx
@@ -13,7 +13,10 @@ describe('BeneficiariasFixed page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: true, data: [] },
+      data: {
+        success: true,
+        data: { items: [], pagination: { page: 1, limit: 0, total: 0 } },
+      },
       isLoading: false,
       isFetching: false,
       isError: false,
@@ -40,7 +43,10 @@ describe('BeneficiariasFixed page', () => {
 
   it('displays error alert when loading fails', () => {
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: true, data: [] },
+      data: {
+        success: true,
+        data: { items: [], pagination: { page: 1, limit: 0, total: 0 } },
+      },
       isLoading: false,
       isError: true,
       error: new Error('Falha ao listar'),
@@ -60,7 +66,11 @@ describe('BeneficiariasFixed page', () => {
 
   it('displays backend error message when request succeeds with failure response', () => {
     (beneficiariasHooks.useBeneficiarias as unknown as Mock).mockReturnValue({
-      data: { success: false, message: 'Erro remoto', data: [] },
+      data: {
+        success: false,
+        message: 'Erro remoto',
+        data: { items: [], pagination: { page: 1, limit: 0, total: 0 } },
+      },
       isLoading: false,
       isError: false,
       isFetching: false,

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -60,15 +60,33 @@ export const beneficiariasService = {
     if (!response.success) {
       return {
         ...response,
-        data: [],
+        data: {
+          items: response.data?.items ?? [],
+          pagination: response.data?.pagination ?? {
+            page: Number(params.page ?? 1),
+            limit: Number(params.limit ?? (response.data?.items?.length ?? 0)),
+            total: 0,
+            totalPages: response.pagination?.totalPages,
+          },
+        },
       } satisfies BeneficiariaListResponse;
     }
 
-    const data = Array.isArray(response.data) ? response.data : [];
+    const items = response.data?.items ?? [];
+    const pagination = response.data?.pagination ?? response.pagination ?? {
+      page: Number(params.page ?? 1),
+      limit: Number(params.limit ?? items.length ?? 0),
+      total: items.length,
+      totalPages: undefined,
+    };
 
     return {
       ...response,
-      data,
+      data: {
+        items,
+        pagination,
+      },
+      pagination,
     } satisfies BeneficiariaListResponse;
   },
   buscarPorId: async (id: string): Promise<BeneficiariaResponse> => {

--- a/apps/frontend/src/types/beneficiarias.ts
+++ b/apps/frontend/src/types/beneficiarias.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse } from '@/types/api';
+import type { ApiResponse, Pagination } from '@/types/api';
 import type { Beneficiaria } from '@/types/shared';
 
 export interface ListBeneficiariasParams {
@@ -9,7 +9,12 @@ export interface ListBeneficiariasParams {
   escolaridade?: string;
 }
 
-export type BeneficiariaListResponse = ApiResponse<Beneficiaria[]>;
+export interface BeneficiariaListData {
+  items: Beneficiaria[];
+  pagination: Pagination;
+}
+
+export type BeneficiariaListResponse = ApiResponse<BeneficiariaListData>;
 
 export type BeneficiariaResponse = ApiResponse<Beneficiaria>;
 


### PR DESCRIPTION
## Summary
- normalize the beneficiárias list API response to expose items and pagination together and update shared types
- adapt services, hooks, and UI pages to consume the normalized payload and remove obsolete logging
- extend hook tests to cover the new response format

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d95bd3b8a08324a16836bce567da0f