### PR TITLE
Implement refresh token support across backend and frontend

### DIFF
--- a/apps/backend/src/__tests__/authRoutes.test.ts
+++ b/apps/backend/src/__tests__/authRoutes.test.ts
@@ -8,7 +8,9 @@ jest.mock('../services', () => ({
   authService: {
     login: jest.fn(),
     getProfile: jest.fn(),
-    generateToken: jest.fn().mockReturnValue('test-token')
+    generateToken: jest.fn().mockReturnValue('test-token'),
+    renewAccessToken: jest.fn(),
+    revokeRefreshToken: jest.fn()
   }
 }));
 import { authService } from '../services';
@@ -42,7 +44,7 @@ describe('Auth and protected routes', () => {
         avatar_url: null,
         active: true
       };
-      (authService.login as jest.Mock).mockResolvedValue({ user, token: 'jwt-token' });
+      (authService.login as jest.Mock).mockResolvedValue({ user, token: 'jwt-token', refreshToken: 'refresh-token' });
 
       const res = await request(app)
         .post('/auth/login')
@@ -52,6 +54,7 @@ describe('Auth and protected routes', () => {
       expect(res.body.user.email).toBe(user.email);
       // Login retorna token no corpo em ambiente de testes/CI
       expect(res.body.token).toBeTruthy();
+      expect(res.body.refreshToken).toBe('refresh-token');
     });
 
     it('should reject invalid credentials', async () => {

--- a/apps/backend/src/database/migrations/048_criar_user_refresh_tokens.sql
+++ b/apps/backend/src/database/migrations/048_criar_user_refresh_tokens.sql
@@ -1,0 +1,23 @@
+-- Tabela responsável por armazenar tokens de refresh individuais por usuário e dispositivo
+CREATE TABLE IF NOT EXISTS user_refresh_tokens (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES usuarios(id) ON DELETE CASCADE,
+  token_id TEXT NOT NULL UNIQUE,
+  token_hash TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  user_agent TEXT,
+  ip_address TEXT,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_refresh_tokens_user_device
+  ON user_refresh_tokens(user_id, device_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_refresh_tokens_expires_at
+  ON user_refresh_tokens(expires_at);
+
+CREATE INDEX IF NOT EXISTS idx_user_refresh_tokens_revoked_at
+  ON user_refresh_tokens(revoked_at);

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -8,6 +8,7 @@ import { env } from '../config/env';
 import {
   changePasswordSchema,
   loginSchema,
+  refreshTokenSchema,
   registerSchema,
   updateProfileSchema
 } from '../validation/schemas/auth.schema';
@@ -35,11 +36,22 @@ interface RegisterSuccessResponse extends AuthResponse {
 interface RefreshResponse {
   message: string;
   token: string;
+  refreshToken?: string;
   user: {
     id: number;
     email?: string;
     role: string;
   };
+}
+
+interface RefreshRequestBody {
+  refreshToken?: string;
+  deviceId?: string;
+}
+
+interface LogoutRequestBody {
+  refreshToken?: string;
+  deviceId?: string;
 }
 
 const allowedSameSite = ['lax', 'strict', 'none'] as const;
@@ -53,6 +65,11 @@ const COOKIE_OPTIONS: CookieOptions = {
   secure: env.NODE_ENV === 'production' || resolvedSameSite === 'none',
   sameSite: resolvedSameSite,
   maxAge: 24 * 60 * 60 * 1000
+};
+
+const REFRESH_COOKIE_OPTIONS: CookieOptions = {
+  ...COOKIE_OPTIONS,
+  maxAge: 7 * 24 * 60 * 60 * 1000
 };
 
 router.use((req, _res, next) => {
@@ -74,7 +91,15 @@ const loginHandler: RequestHandler<
 ) => {
   try {
     const ipAddress = req.ip || req.socket.remoteAddress || 'unknown';
-    const result = await authService.login(req.body.email, req.body.password, ipAddress);
+    const userAgent = req.get('user-agent') || null;
+    const deviceId = req.body.deviceId ?? null;
+    const result = await authService.login(
+      req.body.email,
+      req.body.password,
+      ipAddress,
+      deviceId,
+      userAgent
+    );
 
     if (!result) {
       res.status(401).json({ error: 'Credenciais inválidas' });
@@ -82,9 +107,13 @@ const loginHandler: RequestHandler<
     }
 
     setAuthCookie(res, result.token);
+    if (result.refreshToken) {
+      setRefreshCookie(res, result.refreshToken);
+    }
     res.json({
       message: 'Login realizado com sucesso',
       token: result.token,
+      refreshToken: result.refreshToken,
       user: result.user
     });
   } catch (error) {
@@ -174,6 +203,31 @@ const changePasswordHandler: RequestHandler<
   }
 };
 
+const logoutHandler: RequestHandler<
+  EmptyParams,
+  { message: string } | { error: string },
+  LogoutRequestBody
+> = async (req, res) => {
+  const providedToken = req.body?.refreshToken;
+  const refreshToken = providedToken ?? getCookieValue(req.headers.cookie, 'refresh_token');
+  const deviceId = req.body?.deviceId ?? null;
+  const userAgent = req.get('user-agent') || null;
+
+  if (refreshToken) {
+    try {
+      await authService.revokeRefreshToken(refreshToken, { deviceId, userAgent });
+    } catch (error) {
+      loggerService.warn('Falha ao revogar refresh token no logout', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  clearAuthCookie(res);
+  clearRefreshCookie(res);
+  res.json({ message: 'Logout realizado com sucesso' });
+};
+
 /**
  * Retorna os dados de perfil do usuário autenticado.
  */
@@ -203,44 +257,65 @@ const profileHandler: RequestHandler<EmptyParams, { user: unknown } | { error: s
 /**
  * Regenera o token JWT baseado na sessão atual.
  */
-const refreshHandler: RequestHandler<EmptyParams, RefreshResponse | { error: string }> = async (
-  req,
-  res
-) => {
+const refreshHandler: RequestHandler<
+  EmptyParams,
+  RefreshResponse | { error: string },
+  RefreshRequestBody
+> = async (req, res) => {
   try {
-    if (!req.user) {
-      res.status(401).json({ error: 'Usuário não autenticado' });
+    const providedToken = req.body?.refreshToken;
+    const refreshToken = providedToken ?? getCookieValue(req.headers.cookie, 'refresh_token');
+
+    if (!refreshToken) {
+      res.status(400).json({ error: 'Refresh token é obrigatório' });
       return;
     }
 
-    const { id, email, role, permissions } = req.user;
+    const userAgent = req.get('user-agent') || null;
+    const ipAddress = req.ip || req.socket.remoteAddress || 'unknown';
+    const deviceId = req.body?.deviceId ?? null;
 
-    if (!email) {
-      loggerService.warn('Usuário autenticado sem e-mail ao renovar token', { userId: id });
-      res.status(400).json({ error: 'Sessão inválida' });
-      return;
+    const result = await authService.renewAccessToken(refreshToken, {
+      deviceId,
+      userAgent,
+      ipAddress
+    });
+
+    setAuthCookie(res, result.token);
+    if (result.refreshToken) {
+      setRefreshCookie(res, result.refreshToken);
     }
 
-    const token = authService.generateToken({ id, email, role, permissions });
-    setAuthCookie(res, token);
+    const role = result.user.papel ?? (result.user as { role?: string }).role ?? '';
+
     res.json({
       message: 'Token renovado',
-      token,
-      user: { id, email, role }
+      token: result.token,
+      refreshToken: result.refreshToken,
+      user: {
+        id: result.user.id,
+        email: result.user.email,
+        role
+      }
     });
   } catch (error) {
+    if (error instanceof Error) {
+      loggerService.warn('Falha ao renovar token com refresh', {
+        error: error.message
+      });
+      res.status(401).json({ error: 'Refresh token inválido ou expirado' });
+      return;
+    }
+
     handleUnexpectedError(res, error, 'Erro ao renovar token');
   }
 };
 
 router.post('/login', validateRequest(loginSchema), loginHandler);
 router.post('/register', validateRequest(registerSchema), registerHandler);
-router.post('/logout', (_req, res) => {
-  clearAuthCookie(res);
-  res.json({ message: 'Logout realizado com sucesso' });
-});
-router.post('/refresh', authenticateToken, refreshHandler);
-router.post('/refresh-token', authenticateToken, refreshHandler);
+router.post('/logout', logoutHandler);
+router.post('/refresh', validateRequest(refreshTokenSchema), refreshHandler);
+router.post('/refresh-token', validateRequest(refreshTokenSchema), refreshHandler);
 router.get('/profile', authenticateToken, profileHandler);
 router.get('/me', authenticateToken, profileHandler);
 router.put('/profile', authenticateToken, validateRequest(updateProfileSchema), updateProfileHandler);
@@ -256,8 +331,22 @@ function setAuthCookie(res: Response, token: string): void {
   }
 }
 
+function setRefreshCookie(res: Response, token: string): void {
+  try {
+    res.cookie('refresh_token', token, REFRESH_COOKIE_OPTIONS);
+  } catch (error) {
+    loggerService.warn('Não foi possível definir cookie de refresh', {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
 function clearAuthCookie(res: Response): void {
   res.clearCookie('auth_token', COOKIE_OPTIONS);
+}
+
+function clearRefreshCookie(res: Response): void {
+  res.clearCookie('refresh_token', REFRESH_COOKIE_OPTIONS);
 }
 
 function handleUnexpectedError(res: Response, error: unknown, logMessage: string): void {
@@ -276,6 +365,25 @@ function normalizeSameSite(value?: string | null): SameSiteOption | undefined {
 
   const normalized = value.toLowerCase() as SameSiteOption;
   return allowedSameSite.includes(normalized) ? normalized : undefined;
+}
+
+function getCookieValue(cookieHeader: string | undefined, name: string): string | undefined {
+  if (!cookieHeader) {
+    return undefined;
+  }
+
+  const cookies = cookieHeader
+    .split(';')
+    .map((cookie) => cookie.trim())
+    .filter(Boolean);
+
+  const target = cookies.find((cookie) => cookie.startsWith(`${name}=`));
+  if (!target) {
+    return undefined;
+  }
+
+  const [, value] = target.split('=');
+  return value ? decodeURIComponent(value) : undefined;
 }
 
 export default router;

--- a/apps/backend/src/services/auth.service.ts
+++ b/apps/backend/src/services/auth.service.ts
@@ -1,13 +1,17 @@
 import { Pool } from 'pg';
-import type { RedisClient } from '../lib/redis';
-import { loggerService } from '../services/logger';
+import { createHash, randomBytes } from 'node:crypto';
+import { v4 as uuidv4 } from 'uuid';
 import bcrypt from 'bcryptjs';
 import jwt, { SignOptions } from 'jsonwebtoken';
+
 import { env } from '../config/env';
+import type { RedisClient } from '../lib/redis';
+import { loggerService } from '../services/logger';
 import type {
   AuthenticatedSessionUser,
   AuthResponse,
   JWTPayload,
+  RefreshSessionResponse,
   RegisterRequest
 } from '../types/auth';
 
@@ -24,10 +28,30 @@ interface DatabaseUser {
   data_atualizacao: Date;
 }
 
+interface RefreshTokenRecord {
+  id: number;
+  user_id: number;
+  token_id: string;
+  token_hash: string;
+  device_id: string;
+  user_agent: string | null;
+  ip_address: string | null;
+  expires_at: Date;
+  revoked_at: Date | null;
+}
+
+interface RefreshTokenMetadata {
+  deviceId?: string | null;
+  userAgent?: string | null;
+  ipAddress?: string | null;
+}
+
 export class AuthService {
   private readonly jwtSecret: string;
   private readonly jwtExpiry: SignOptions['expiresIn'];
   private readonly CACHE_TTL = 300; // 5 minutos
+  private readonly refreshTokenTTL: number;
+  private readonly refreshHashRounds = 12;
 
   constructor(
     private pool: Pool,
@@ -35,6 +59,132 @@ export class AuthService {
   ) {
     this.jwtSecret = env.JWT_SECRET;
     this.jwtExpiry = env.JWT_EXPIRY;
+    // 7 dias por padrão para tokens de refresh
+    this.refreshTokenTTL = 7 * 24 * 60 * 60 * 1000;
+  }
+
+  private buildSessionUser(user: DatabaseUser): AuthenticatedSessionUser {
+    return {
+      id: user.id,
+      email: user.email,
+      nome: user.nome,
+      papel: user.papel,
+      avatar_url: user.avatar_url ?? undefined,
+      ultimo_login: user.ultimo_login,
+      data_criacao: user.data_criacao,
+      data_atualizacao: user.data_atualizacao
+    };
+  }
+
+  private normalizeDeviceId(deviceId?: string | null, userAgent?: string | null): string {
+    const trimmed = (deviceId ?? '').trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+
+    if (userAgent && userAgent.trim().length > 0) {
+      return createHash('sha256').update(userAgent.trim()).digest('hex');
+    }
+
+    return 'unknown';
+  }
+
+  private getRefreshTokenExpiryDate(): Date {
+    return new Date(Date.now() + this.refreshTokenTTL);
+  }
+
+  private createRefreshTokenPair() {
+    const tokenId = uuidv4();
+    const secret = randomBytes(48).toString('hex');
+    return {
+      tokenId,
+      secret,
+      token: `${tokenId}.${secret}`
+    };
+  }
+
+  private parseRefreshToken(refreshToken?: string | null) {
+    if (!refreshToken) {
+      return null;
+    }
+
+    const [tokenId, secret] = refreshToken.split('.');
+
+    if (!tokenId || !secret) {
+      return null;
+    }
+
+    return { tokenId, secret };
+  }
+
+  private async persistRefreshToken(
+    userId: number,
+    metadata: RefreshTokenMetadata
+  ): Promise<{ token: string; deviceId: string; expiresAt: Date }> {
+    const { tokenId, secret, token } = this.createRefreshTokenPair();
+    const tokenHash = await bcrypt.hash(secret, this.refreshHashRounds);
+    const expiresAt = this.getRefreshTokenExpiryDate();
+    const normalizedDeviceId = this.normalizeDeviceId(metadata.deviceId, metadata.userAgent);
+
+    await this.pool.query(
+      `INSERT INTO user_refresh_tokens (user_id, token_id, token_hash, device_id, user_agent, ip_address, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (user_id, device_id)
+       DO UPDATE SET token_id = EXCLUDED.token_id,
+                     token_hash = EXCLUDED.token_hash,
+                     expires_at = EXCLUDED.expires_at,
+                     user_agent = EXCLUDED.user_agent,
+                     ip_address = EXCLUDED.ip_address,
+                     updated_at = NOW(),
+                     revoked_at = NULL`,
+      [userId, tokenId, tokenHash, normalizedDeviceId, metadata.userAgent ?? null, metadata.ipAddress ?? null, expiresAt]
+    );
+
+    return { token, deviceId: normalizedDeviceId, expiresAt };
+  }
+
+  private async rotateRefreshToken(
+    recordId: number,
+    metadata: RefreshTokenMetadata
+  ): Promise<{ token: string; deviceId: string; expiresAt: Date }> {
+    const { tokenId, secret, token } = this.createRefreshTokenPair();
+    const tokenHash = await bcrypt.hash(secret, this.refreshHashRounds);
+    const expiresAt = this.getRefreshTokenExpiryDate();
+    const normalizedDeviceId = this.normalizeDeviceId(metadata.deviceId, metadata.userAgent);
+
+    await this.pool.query(
+      `UPDATE user_refresh_tokens
+       SET token_id = $1,
+           token_hash = $2,
+           device_id = $3,
+           user_agent = $4,
+           ip_address = $5,
+           expires_at = $6,
+           updated_at = NOW(),
+           revoked_at = NULL
+       WHERE id = $7`,
+      [
+        tokenId,
+        tokenHash,
+        normalizedDeviceId,
+        metadata.userAgent ?? null,
+        metadata.ipAddress ?? null,
+        expiresAt,
+        recordId
+      ]
+    );
+
+    return { token, deviceId: normalizedDeviceId, expiresAt };
+  }
+
+  private async revokeRefreshTokenRecord(recordId: number): Promise<void> {
+    await this.pool.query(
+      `UPDATE user_refresh_tokens
+       SET revoked_at = NOW(),
+           updated_at = NOW()
+       WHERE id = $1`,
+      [recordId]
+    );
   }
 
   /**
@@ -54,7 +204,13 @@ export class AuthService {
    * @param ipAddress Endereço IP utilizado para auditoria do acesso.
    * @returns Token JWT e dados básicos do usuário autenticado ou null se inválido.
    */
-  async login(email: string, password: string, ipAddress: string): Promise<AuthResponse | null> {
+  async login(
+    email: string,
+    password: string,
+    ipAddress: string,
+    deviceId?: string | null,
+    userAgent?: string | null
+  ): Promise<AuthResponse | null> {
     try {
       // Buscar usuário
       const userQuery = "SELECT * FROM usuarios WHERE email = $1 AND ativo = true";
@@ -87,24 +243,18 @@ export class AuthService {
         role: user.papel
       });
 
-      loggerService.info(`Successful login: ${email} from ${ipAddress}`);
+      const sessionUser = this.buildSessionUser(user);
+      const refreshToken = await this.persistRefreshToken(user.id, {
+        deviceId,
+        userAgent,
+        ipAddress
+      });
 
-      // Remover campos sensíveis
-      const { senha_hash, ...userWithoutPassword } = user;
-      const sessionUser: AuthenticatedSessionUser = {
-        id: userWithoutPassword.id,
-        email: userWithoutPassword.email,
-        nome: userWithoutPassword.nome,
-        papel: userWithoutPassword.papel,
-        avatar_url: userWithoutPassword.avatar_url ?? undefined,
-        ultimo_login: userWithoutPassword.ultimo_login,
-        data_criacao: userWithoutPassword.data_criacao,
-        data_atualizacao: userWithoutPassword.data_atualizacao
-      };
+      loggerService.info(`Successful login: ${email} from ${ipAddress}`);
 
       // Retorna imediatamente em ambientes sem Redis disponível
       if (!env.REDIS_HOST) {
-        return { token, user: sessionUser };
+        return { token, refreshToken: refreshToken.token, user: sessionUser };
       }
 
       // Cache (ignorar falhas de Redis em dev)
@@ -121,6 +271,7 @@ export class AuthService {
 
       return {
         token,
+        refreshToken: refreshToken.token,
         user: sessionUser
       };
     } catch (error) {
@@ -152,6 +303,136 @@ export class AuthService {
     }
   }
 
+  async renewAccessToken(
+    refreshToken: string,
+    metadata: RefreshTokenMetadata
+  ): Promise<RefreshSessionResponse> {
+    const parsed = this.parseRefreshToken(refreshToken);
+
+    if (!parsed) {
+      throw new Error('Refresh token inválido');
+    }
+
+    const tokenResult = await this.pool.query(
+      `SELECT id, user_id, token_id, token_hash, device_id, user_agent, ip_address, expires_at, revoked_at
+       FROM user_refresh_tokens
+       WHERE token_id = $1`,
+      [parsed.tokenId]
+    );
+
+    if (tokenResult.rowCount === 0) {
+      throw new Error('Refresh token não encontrado');
+    }
+
+    const record = tokenResult.rows[0] as RefreshTokenRecord;
+
+    if (record.revoked_at) {
+      throw new Error('Refresh token revogado');
+    }
+
+    const expiresAt = new Date(record.expires_at);
+    if (expiresAt.getTime() <= Date.now()) {
+      await this.revokeRefreshTokenRecord(record.id);
+      throw new Error('Refresh token expirado');
+    }
+
+    const normalizedDeviceId = this.normalizeDeviceId(metadata.deviceId, metadata.userAgent ?? record.user_agent);
+
+    if (record.device_id && record.device_id !== normalizedDeviceId) {
+      throw new Error('Dispositivo não autorizado para este token');
+    }
+
+    const validSecret = await bcrypt.compare(parsed.secret, record.token_hash);
+
+    if (!validSecret) {
+      await this.revokeRefreshTokenRecord(record.id);
+      throw new Error('Refresh token inválido');
+    }
+
+    const userResult = await this.pool.query(
+      "SELECT * FROM usuarios WHERE id = $1 AND ativo = true",
+      [record.user_id]
+    );
+
+    if (userResult.rowCount === 0) {
+      await this.revokeRefreshTokenRecord(record.id);
+      throw new Error('Usuário associado não encontrado ou inativo');
+    }
+
+    const user = userResult.rows[0] as DatabaseUser;
+    const sessionUser = this.buildSessionUser(user);
+
+    const token = this.generateToken({
+      id: user.id,
+      email: user.email,
+      role: user.papel
+    });
+
+    const rotated = await this.rotateRefreshToken(record.id, {
+      deviceId: normalizedDeviceId,
+      userAgent: metadata.userAgent ?? record.user_agent,
+      ipAddress: metadata.ipAddress ?? record.ip_address
+    });
+
+    loggerService.info(`Refresh token renovado para o usuário ${user.email}`);
+
+    return {
+      token,
+      refreshToken: rotated.token,
+      user: sessionUser
+    };
+  }
+
+  async revokeRefreshToken(refreshToken: string, metadata?: RefreshTokenMetadata): Promise<void> {
+    const parsed = this.parseRefreshToken(refreshToken);
+
+    if (!parsed) {
+      throw new Error('Refresh token inválido');
+    }
+
+    const tokenResult = await this.pool.query(
+      `SELECT id, device_id FROM user_refresh_tokens WHERE token_id = $1`,
+      [parsed.tokenId]
+    );
+
+    if (tokenResult.rowCount === 0) {
+      throw new Error('Refresh token não encontrado');
+    }
+
+    const record = tokenResult.rows[0] as RefreshTokenRecord;
+
+    if (metadata?.deviceId) {
+      const normalizedDeviceId = this.normalizeDeviceId(metadata.deviceId, metadata.userAgent);
+      if (record.device_id && record.device_id !== normalizedDeviceId) {
+        throw new Error('Dispositivo não autorizado');
+      }
+    }
+
+    await this.revokeRefreshTokenRecord(record.id);
+  }
+
+  async revokeAllRefreshTokensForUser(userId: number, deviceId?: string | null): Promise<void> {
+    if (deviceId) {
+      const normalizedDeviceId = this.normalizeDeviceId(deviceId, null);
+      await this.pool.query(
+        `UPDATE user_refresh_tokens
+         SET revoked_at = NOW(),
+             updated_at = NOW()
+         WHERE user_id = $1 AND device_id = $2 AND revoked_at IS NULL`,
+        [userId, normalizedDeviceId]
+      );
+      return;
+    }
+
+    await this.pool.query(
+      `UPDATE user_refresh_tokens
+       SET revoked_at = NOW(),
+           updated_at = NOW()
+       WHERE user_id = $1 AND revoked_at IS NULL`,
+      [userId]
+    );
+  }
+
   /**
    * Registra um novo usuário persistindo os dados e retornando um token de sessão.
    * @param params Dados necessários para criação do usuário.
@@ -177,16 +458,7 @@ export class AuthService {
     const user = result.rows[0] as DatabaseUser;
     const token = this.generateToken({ id: user.id, email: user.email, role: user.papel });
 
-    const sessionUser: AuthenticatedSessionUser = {
-      id: user.id,
-      email: user.email,
-      nome: user.nome,
-      papel: user.papel,
-      avatar_url: user.avatar_url ?? undefined,
-      ultimo_login: user.ultimo_login,
-      data_criacao: user.data_criacao,
-      data_atualizacao: user.data_atualizacao
-    };
+    const sessionUser = this.buildSessionUser(user);
 
     return { token, user: sessionUser };
   }
@@ -241,5 +513,6 @@ export class AuthService {
     }
     const newHash = await bcrypt.hash(newPassword, 12);
     await this.pool.query('UPDATE usuarios SET senha_hash = $1, data_atualizacao = NOW() WHERE id = $2', [newHash, userId]);
+    await this.revokeAllRefreshTokensForUser(userId);
   }
 }

--- a/apps/backend/src/types/auth.ts
+++ b/apps/backend/src/types/auth.ts
@@ -18,10 +18,12 @@ export interface User {
 export interface LoginRequest {
   email: string;
   password: string;
+  deviceId?: string;
 }
 
 export interface LoginResponse {
   token: string;
+  refreshToken?: string;
   user: {
     id: number;
     name: string;
@@ -80,5 +82,11 @@ export interface AuthenticatedSessionUser {
 
 export interface AuthResponse {
   token: string;
+  refreshToken?: string;
   user: AuthenticatedSessionUser;
+}
+
+export interface RefreshSessionResponse extends AuthResponse {
+  token: string;
+  refreshToken?: string;
 }

--- a/apps/backend/src/validation/schemas/auth.schema.ts
+++ b/apps/backend/src/validation/schemas/auth.schema.ts
@@ -8,7 +8,8 @@ const emptyObject = z.object({}).optional();
 export const loginSchema = z.object({
   body: z.object({
     email: z.string().email('Formato de email inválido'),
-    password: z.string().min(1, 'Senha é obrigatória')
+    password: z.string().min(1, 'Senha é obrigatória'),
+    deviceId: z.string().min(1).optional()
   }),
   query: emptyObject,
   params: emptyObject
@@ -50,6 +51,18 @@ export const changePasswordSchema = z.object({
     currentPassword: z.string().min(1, 'Senha atual é obrigatória'),
     newPassword: z.string().min(6, 'Nova senha deve ter pelo menos 6 caracteres')
   }),
+  query: emptyObject,
+  params: emptyObject
+});
+
+export const refreshTokenSchema = z.object({
+  body: z
+    .object({
+      refreshToken: z.string().min(1).optional(),
+      deviceId: z.string().min(1).optional()
+    })
+    .partial()
+    .default({}),
   query: emptyObject,
   params: emptyObject
 });

--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -77,16 +77,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       setLoading(true);
       const response = await authService.login({ email, password });
-      // Tipagem explícita do retorno esperado
-      type LoginResponse = { token?: string; user?: User };
-      const resp = response as LoginResponse;
-      if (resp.token) {
-        localStorage.setItem('auth_token', resp.token);
-        localStorage.setItem('token', resp.token);
+      const accessToken = response.token ?? response.accessToken ?? null;
+      if (accessToken) {
+        localStorage.setItem('auth_token', accessToken);
+        localStorage.setItem('token', accessToken);
       }
-      if (resp.user) {
-        localStorage.setItem('user', JSON.stringify(resp.user));
-        setUser(resp.user);
+      if (response.user) {
+        localStorage.setItem('user', JSON.stringify(response.user));
+        setUser(response.user);
       }
       return {};
     } catch (error) {
@@ -102,6 +100,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       await authService.logout();
     } finally {
       localStorage.removeItem("auth_token");
+      localStorage.removeItem("token");
       localStorage.removeItem("user");
       setUser(null);
       setLoading(false);

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -3,6 +3,8 @@ import axios from 'axios';
 
 export interface AuthResponse {
   token: string;
+  accessToken?: string;
+  refreshToken?: string;
   user: {
     id: number;
     email: string;
@@ -17,8 +19,21 @@ export interface LoginCredentials {
   password: string;
 }
 
+export interface RefreshSessionResponse {
+  message: string;
+  token: string;
+  refreshToken?: string;
+  user: {
+    id: number;
+    email?: string;
+    role: string;
+  };
+}
+
 export class AuthService {
   private static instance: AuthService;
+
+  private readonly deviceStorageKey = 'auth_device_id';
 
   private constructor() {}
 
@@ -29,9 +44,34 @@ export class AuthService {
     return AuthService.instance;
   }
 
+  private getDeviceId(): string {
+    if (typeof window === 'undefined') {
+      return 'server';
+    }
+
+    const storageKey = this.deviceStorageKey;
+    const existing = window.localStorage.getItem(storageKey);
+    if (existing) {
+      return existing;
+    }
+
+    const generated =
+      typeof window.crypto !== 'undefined' && typeof window.crypto.randomUUID === 'function'
+        ? window.crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+
+    window.localStorage.setItem(storageKey, generated);
+    return generated;
+  }
+
   async login(credentials: LoginCredentials): Promise<AuthResponse> {
     try {
-      const response = await api.post<AuthResponse>('/auth/login', credentials, { withCredentials: true });
+      const deviceId = this.getDeviceId();
+      const response = await api.post<AuthResponse>(
+        '/auth/login',
+        { ...credentials, deviceId },
+        { withCredentials: true }
+      );
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -43,19 +83,31 @@ export class AuthService {
 
   async logout(): Promise<void> {
     try {
-      await api.post('/auth/logout', undefined, { withCredentials: true });
-      // Limpar token e dados do usuário localmente
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('user');
+      const deviceId = this.getDeviceId();
+      await api.post(
+        '/auth/logout',
+        { deviceId },
+        { withCredentials: true }
+      );
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
+    } finally {
+      // Limpar token e dados do usuário localmente
+      localStorage.removeItem('auth_token');
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
     }
   }
 
-  async refreshToken(): Promise<string> {
+  async refreshToken(): Promise<RefreshSessionResponse> {
     try {
-      const response = await api.post<{ message: string; token: string }>('/auth/refresh', undefined, { withCredentials: true });
-      return response.data.token;
+      const deviceId = this.getDeviceId();
+      const response = await api.post<RefreshSessionResponse>(
+        '/auth/refresh',
+        { deviceId },
+        { withCredentials: true }
+      );
+      return response.data;
     } catch (error) {
       throw new Error('Erro ao renovar token');
     }


### PR DESCRIPTION
## Summary
- add a persistent refresh-token store and rotation flow in the auth service and schema validation
- extend auth routes to manage refresh cookies, token renewal, and logout revocation
- align the frontend auth client with device identifiers and the new refresh contract

## Testing
- npm --prefix apps/backend test -- authRoutes *(fails: ansiRegex is not a function when running Jest reporters)*

------
https://chatgpt.com/codex/tasks/task_e_68d95bcf0b6c8324bcb894559ad71bb3