### PR TITLE
Fix auth hook token cleanup and logout handling

### DIFF
--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -92,30 +92,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Armazenar token de acesso
       if (resp.token) {
         localStorage.setItem(AUTH_TOKEN_KEY, resp.token);
-        // Limpar chaves legadas
-        if (AUTH_TOKEN_KEY !== 'auth_token') {
-          localStorage.removeItem('auth_token');
+        if (AUTH_TOKEN_KEY !== "auth_token") {
+          localStorage.removeItem("auth_token");
         }
-        if (AUTH_TOKEN_KEY !== 'token') {
-          localStorage.removeItem('token');
+        if (AUTH_TOKEN_KEY !== "token") {
+          localStorage.removeItem("token");
         }
       }
       if (resp.user) {
         localStorage.setItem(USER_KEY, JSON.stringify(resp.user));
-        if (USER_KEY !== 'user') {
-          localStorage.removeItem('user');
+        if (USER_KEY !== "user") {
+          localStorage.removeItem("user");
         }
         setUser(resp.user);
-=======
-      const accessToken = response.token ?? response.accessToken ?? null;
-      if (accessToken) {
-        localStorage.setItem('auth_token', accessToken);
-        localStorage.setItem('token', accessToken);
-      }
-      if (response.user) {
-        localStorage.setItem('user', JSON.stringify(response.user));
-        setUser(response.user);
->>>>>>> main
       }
       return {};
     } catch (error) {
@@ -130,20 +119,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       await authService.logout();
     } finally {
-<<<<<<< HEAD
-      const tokenKeys = new Set([
-        'token',
-        'auth_token',
-        AUTH_TOKEN_KEY
-      ]);
+      const tokenKeys = new Set(["token", "auth_token", AUTH_TOKEN_KEY]);
       tokenKeys.forEach((key) => localStorage.removeItem(key));
-      localStorage.removeItem('user');
-      localStorage.removeItem(USER_KEY);
-=======
-      localStorage.removeItem("auth_token");
-      localStorage.removeItem("token");
-      localStorage.removeItem("user");
->>>>>>> main
+
+      const userKeys = new Set(["user", USER_KEY]);
+      userKeys.forEach((key) => localStorage.removeItem(key));
+
       setUser(null);
       setLoading(false);
     }

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -83,32 +83,15 @@ export class AuthService {
 
   async logout(): Promise<void> {
     try {
-      const deviceId = this.getDeviceId();
-      await api.post(
-        '/auth/logout',
-        { deviceId },
-        { withCredentials: true }
-      );
-      // Limpar token e dados do usuário localmente
-      const tokenKeys = new Set([
-        'token',
-        'auth_token',
-        AUTH_TOKEN_KEY
-      ]);
-      tokenKeys.forEach((key) => localStorage.removeItem(key));
-=======
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('token');
->>>>>>> main
-      localStorage.removeItem('user');
-      localStorage.removeItem(USER_KEY);
+      await api.post('/auth/logout', undefined, { withCredentials: true });
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     } finally {
-      // Limpar token e dados do usuário localmente
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
+      const tokenKeys = new Set(['token', 'auth_token', AUTH_TOKEN_KEY]);
+      tokenKeys.forEach((key) => localStorage.removeItem(key));
+
+      const userKeys = new Set(['user', USER_KEY]);
+      userKeys.forEach((key) => localStorage.removeItem(key));
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve merge artifacts in the auth hook while centralizing token and user storage cleanup
- update the auth service logout flow to reuse the shared storage keys and keep API usage aligned with existing tests

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d977341d708324b010d4bd9a284d35