### PR TITLE
Refine auth logout token cleanup

### DIFF
--- a/apps/frontend/src/services/auth.service.test.ts
+++ b/apps/frontend/src/services/auth.service.test.ts
@@ -14,17 +14,29 @@ describe('AuthService', () => {
   });
 
   it('should remove stored tokens after logout', async () => {
+    localStorage.setItem('test_auth_token', 'token123');
     localStorage.setItem('auth_token', 'token123');
     localStorage.setItem('token', 'token123');
+    localStorage.setItem('test_user', JSON.stringify({ id: 1 }));
     localStorage.setItem('user', JSON.stringify({ id: 1 }));
 
+    const getDeviceIdSpy = vi
+      .spyOn(authService as unknown as { getDeviceId: () => string }, 'getDeviceId')
+      .mockReturnValue('test-device-id');
     const postSpy = vi.spyOn(api, 'post').mockResolvedValue({} as any);
 
     await authService.logout();
 
-    expect(postSpy).toHaveBeenCalledWith('/auth/logout', undefined, { withCredentials: true });
+    expect(getDeviceIdSpy).toHaveBeenCalled();
+    expect(postSpy).toHaveBeenCalledWith(
+      '/auth/logout',
+      { deviceId: 'test-device-id' },
+      { withCredentials: true }
+    );
+    expect(localStorage.getItem('test_auth_token')).toBeNull();
     expect(localStorage.getItem('auth_token')).toBeNull();
     expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('test_user')).toBeNull();
     expect(localStorage.getItem('user')).toBeNull();
   });
 });

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -82,6 +82,16 @@ export class AuthService {
   }
 
   async logout(): Promise<void> {
+    const tokenKeys = new Set([
+      AUTH_TOKEN_KEY,
+      'auth_token',
+      'token'
+    ]);
+    const userKeys = new Set([
+      USER_KEY,
+      'user'
+    ]);
+
     try {
       const deviceId = this.getDeviceId();
       await api.post(
@@ -89,26 +99,11 @@ export class AuthService {
         { deviceId },
         { withCredentials: true }
       );
-      // Limpar token e dados do usuário localmente
-      const tokenKeys = new Set([
-        'token',
-        'auth_token',
-        AUTH_TOKEN_KEY
-      ]);
-      tokenKeys.forEach((key) => localStorage.removeItem(key));
-=======
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('token');
->>>>>>> main
-      localStorage.removeItem('user');
-      localStorage.removeItem(USER_KEY);
     } catch (error) {
       console.error('Erro ao fazer logout:', error);
     } finally {
-      // Limpar token e dados do usuário localmente
-      localStorage.removeItem('auth_token');
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
+      tokenKeys.forEach((key) => localStorage.removeItem(key));
+      userKeys.forEach((key) => localStorage.removeItem(key));
     }
   }
 


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from logout implementation and consolidate token cleanup across code paths
- ensure logout request sends the device identifier while clearing both token and user keys
- adjust auth service unit test to reflect the request payload and verify all token and user keys are cleared

## Testing
- npm run test:frontend *(fails: existing merge conflict markers in apps/frontend/src/hooks/useAuth.tsx prevent Vitest from completing)*

------
https://chatgpt.com/codex/tasks/task_e_68d977321278832498e3c2f1ee851224