### PR TITLE
refactor: extract beneficiaria form hook and add tests

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useBeneficiariaForm.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useBeneficiariaForm.test.ts
@@ -1,0 +1,158 @@
+import { act, renderHook } from '@testing-library/react';
+import { vi, describe, beforeEach, it, expect } from 'vitest';
+
+vi.mock('@/hooks/useApi', () => ({
+  useCreateBeneficiaria: vi.fn(),
+}));
+
+vi.mock('@/hooks/useFormValidation', () => ({
+  useBeneficiariaValidation: vi.fn(),
+}));
+
+vi.mock('@/hooks/useCEP', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}));
+
+import { useBeneficiariaForm } from '../useBeneficiariaForm';
+import { useCreateBeneficiaria } from '@/hooks/useApi';
+import { useBeneficiariaValidation } from '@/hooks/useFormValidation';
+import useCEP from '@/hooks/useCEP';
+
+describe('useBeneficiariaForm', () => {
+  const mutateAsync = vi.fn();
+  const validateForm = vi.fn();
+  const validateField = vi.fn();
+  const clearFieldError = vi.fn();
+  const fetchCEP = vi.fn();
+
+  const useCreateBeneficiariaMock = vi.mocked(useCreateBeneficiaria);
+  const useBeneficiariaValidationMock = vi.mocked(useBeneficiariaValidation);
+  const useCEPMock = vi.mocked(useCEP);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useCreateBeneficiariaMock.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    });
+
+    useBeneficiariaValidationMock.mockReturnValue({
+      validateForm,
+      validateField,
+      clearFieldError,
+    });
+
+    useCEPMock.mockReturnValue({
+      fetchCEP,
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('submits sanitized payload and triggers success callback', async () => {
+    validateForm.mockReturnValue({ isValid: true, errors: {} });
+    mutateAsync.mockResolvedValueOnce({});
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() => useBeneficiariaForm({ onSuccess }));
+
+    act(() => {
+      result.current.handleInputChange('nome_completo', 'Fulana de Tal');
+      result.current.handleInputChange('cpf', '123.456.789-01');
+      result.current.handleInputChange('data_nascimento', '2000-01-01');
+      result.current.handleInputChange('contato1', '(11) 99999-9999');
+      result.current.handleInputChange('contato2', '(11) 98888-7777');
+      result.current.handleInputChange('rg', '1234567');
+      result.current.handleInputChange('orgao_emissor_rg', 'SSP');
+      result.current.handleInputChange('data_emissao_rg', '2020-01-01');
+      result.current.handleInputChange('endereco', 'Rua X, 123');
+      result.current.handleInputChange('bairro', 'Centro');
+      result.current.handleInputChange('nis', '123');
+      result.current.handleInputChange('referencia', 'indicacao');
+      result.current.handleInputChange('programa_servico', 'programa');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      nome_completo: 'Fulana de Tal',
+      cpf: '12345678901',
+      rg: '1234567',
+      orgao_emissor_rg: 'SSP',
+      data_emissao_rg: '2020-01-01',
+      data_nascimento: '2000-01-01',
+      endereco: 'Rua X, 123',
+      telefone: '11999999999',
+      contato2: '11988887777',
+      bairro: 'Centro',
+      nis: '123',
+      referencia: 'indicacao',
+      programa_servico: 'programa',
+    });
+
+    expect(result.current.success).toBe(true);
+    expect(result.current.successMessage).toBe('Beneficiária cadastrada com sucesso! Redirecionando...');
+    expect(onSuccess).toHaveBeenCalledWith({ message: 'Beneficiária cadastrada com sucesso! Redirecionando...' });
+  });
+
+  it('sets error when validation fails', async () => {
+    validateForm.mockReturnValue({ isValid: false, errors: { nome_completo: 'obrigatório' } });
+    const { result } = renderHook(() => useBeneficiariaForm());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(result.current.error).toBe('Verifique os campos destacados');
+  });
+
+  it('translates API errors when mutation fails', async () => {
+    validateForm.mockReturnValue({ isValid: true, errors: {} });
+    mutateAsync.mockRejectedValueOnce({ response: { data: { message: 'CPF inválido' } } });
+
+    const { result } = renderHook(() => useBeneficiariaForm());
+
+    act(() => {
+      result.current.handleInputChange('data_nascimento', '2000-01-01');
+      result.current.handleInputChange('contato1', '(11) 99999-9999');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.error).toBe('Erro ao cadastrar beneficiária: Verifique o CPF informado. Use um CPF válido.');
+    expect(result.current.success).toBe(false);
+  });
+
+  it('preenche dados de endereço a partir do CEP', async () => {
+    validateForm.mockReturnValue({ isValid: true, errors: {} });
+    fetchCEP.mockResolvedValueOnce({
+      logradouro: 'Rua Y',
+      bairro: 'Bairro Z',
+      localidade: 'Cidade W',
+      uf: 'SP',
+    });
+
+    const { result } = renderHook(() => useBeneficiariaForm());
+
+    act(() => {
+      result.current.handleInputChange('cep', '01001-000');
+    });
+
+    await act(async () => {
+      await result.current.handleCepBlur();
+    });
+
+    expect(fetchCEP).toHaveBeenCalledWith('01001-000');
+    expect(result.current.formData.endereco).toBe('Rua Y');
+    expect(result.current.formData.bairro).toBe('Bairro Z');
+    expect(result.current.formData.cidade).toBe('Cidade W');
+    expect(result.current.formData.estado).toBe('SP');
+  });
+});

--- a/apps/frontend/src/hooks/useBeneficiariaForm.ts
+++ b/apps/frontend/src/hooks/useBeneficiariaForm.ts
@@ -1,0 +1,208 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useCreateBeneficiaria } from '@/hooks/useApi';
+import { useBeneficiariaValidation } from '@/hooks/useFormValidation';
+import { translateErrorMessage } from '@/lib/apiError';
+import useCEP from '@/hooks/useCEP';
+
+type FormFieldErrors = Record<string, string | undefined>;
+
+type UseBeneficiariaFormOptions = {
+  onSuccess?: (payload: { message: string }) => void;
+};
+
+type BeneficiariaFormData = {
+  nome_completo: string;
+  cpf: string;
+  rg: string;
+  orgao_emissor_rg: string;
+  data_emissao_rg: string;
+  data_nascimento: string;
+  endereco: string;
+  bairro: string;
+  cep: string;
+  cidade: string;
+  estado: string;
+  nis: string;
+  contato1: string;
+  contato2: string;
+  referencia: string;
+  data_inicio_instituto: string;
+  programa_servico: string;
+};
+
+export const createInitialBeneficiariaFormData = (): BeneficiariaFormData => ({
+  nome_completo: '',
+  cpf: '',
+  rg: '',
+  orgao_emissor_rg: '',
+  data_emissao_rg: '',
+  data_nascimento: '',
+  endereco: '',
+  bairro: '',
+  cep: '',
+  cidade: '',
+  estado: '',
+  nis: '',
+  contato1: '',
+  contato2: '',
+  referencia: '',
+  data_inicio_instituto: new Date().toISOString().split('T')[0],
+  programa_servico: '',
+});
+
+const sanitizePayload = (formData: BeneficiariaFormData) => {
+  const digits = (value: string) => value.replace(/\D/g, '');
+
+  return {
+    nome_completo: formData.nome_completo,
+    cpf: digits(formData.cpf),
+    rg: formData.rg || undefined,
+    orgao_emissor_rg: formData.orgao_emissor_rg || undefined,
+    data_emissao_rg: formData.data_emissao_rg || null,
+    data_nascimento: formData.data_nascimento,
+    endereco: formData.endereco || undefined,
+    telefone: digits(formData.contato1),
+    contato2: formData.contato2 ? digits(formData.contato2) : null,
+    bairro: formData.bairro || undefined,
+    nis: formData.nis || null,
+    referencia: formData.referencia || null,
+    programa_servico: formData.programa_servico || null,
+  };
+};
+
+export const useBeneficiariaForm = (options: UseBeneficiariaFormOptions = {}) => {
+  const [formData, setFormData] = useState<BeneficiariaFormData>(createInitialBeneficiariaFormData);
+  const [fieldErrors, setFieldErrors] = useState<FormFieldErrors>({});
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const { validateField, validateForm, clearFieldError } = useBeneficiariaValidation();
+  const { mutateAsync, isPending } = useCreateBeneficiaria();
+  const { fetchCEP, loading: loadingCEP, error: cepError } = useCEP();
+
+  const handleInputChange = useCallback((field: keyof BeneficiariaFormData, value: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+
+    setFieldErrors((prev) => {
+      const keysToClear = new Set<string>([field]);
+      if (field === 'contato1') {
+        keysToClear.add('telefone');
+      }
+
+      let changed = false;
+      const next = { ...prev };
+      keysToClear.forEach((key) => {
+        if (next[key]) {
+          delete next[key];
+          changed = true;
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, []);
+
+  const onBlurValidate = useCallback((field: string, value: string) => {
+    const message = validateField(field, value);
+    setFieldErrors((prev) => {
+      const next = { ...prev };
+      if (message) {
+        next[field] = message;
+      } else {
+        delete next[field];
+      }
+      return next;
+    });
+    if (!message) {
+      clearFieldError(field);
+    }
+  }, [clearFieldError, validateField]);
+
+  const validateBeforeSubmit = useCallback(() => {
+    const { isValid, errors: validationErrors } = validateForm(formData as any);
+    const combinedErrors: FormFieldErrors = { ...validationErrors };
+
+    if (!formData.contato1?.replace(/\D/g, '')) {
+      combinedErrors.contato1 = 'Telefone é obrigatório';
+    }
+
+    if (!formData.data_nascimento) {
+      combinedErrors.data_nascimento = 'Data de nascimento é obrigatória';
+    }
+
+    setFieldErrors(combinedErrors);
+
+    if (!isValid || Object.keys(combinedErrors).length > 0) {
+      setError('Verifique os campos destacados');
+      return false;
+    }
+
+    setError(null);
+    return true;
+  }, [formData, validateForm]);
+
+  const handleCepBlur = useCallback(async () => {
+    const data = await fetchCEP(formData.cep);
+    if (data) {
+      setFormData((prev) => ({
+        ...prev,
+        endereco: data.logradouro || prev.endereco,
+        bairro: data.bairro || prev.bairro,
+        cidade: data.localidade || prev.cidade,
+        estado: data.uf || prev.estado,
+      }));
+    }
+  }, [fetchCEP, formData.cep]);
+
+  const handleSubmit = useCallback(async (event?: React.FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+
+    if (!validateBeforeSubmit()) {
+      return;
+    }
+
+    setError(null);
+    setSuccess(false);
+    setSuccessMessage(null);
+
+    try {
+      const payload = sanitizePayload(formData);
+      await mutateAsync(payload as any);
+
+      const message = 'Beneficiária cadastrada com sucesso! Redirecionando...';
+      setSuccess(true);
+      setSuccessMessage(message);
+      options.onSuccess?.({ message });
+    } catch (err: any) {
+      console.error('Erro ao cadastrar beneficiária:', err);
+      const apiMessage = err?.response?.data?.message || err?.response?.data?.error || err?.message;
+      const friendly = translateErrorMessage(apiMessage);
+      setSuccess(false);
+      setSuccessMessage(null);
+      setError(`Erro ao cadastrar beneficiária: ${friendly}`);
+    }
+  }, [formData, mutateAsync, options, validateBeforeSubmit]);
+
+  const isSubmitDisabled = useMemo(() => isPending, [isPending]);
+
+  return {
+    formData,
+    fieldErrors,
+    error,
+    success,
+    successMessage,
+    loading: isSubmitDisabled,
+    loadingCEP,
+    cepError,
+    handleInputChange,
+    onBlurValidate,
+    handleSubmit,
+    handleCepBlur,
+  };
+};
+
+export default useBeneficiariaForm;

--- a/apps/frontend/src/pages/__tests__/CadastroBeneficiaria.test.tsx
+++ b/apps/frontend/src/pages/__tests__/CadastroBeneficiaria.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+
+vi.mock('@/hooks/useBeneficiariaForm', () => ({
+  useBeneficiariaForm: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+import CadastroBeneficiaria from '../CadastroBeneficiaria';
+import { useBeneficiariaForm } from '@/hooks/useBeneficiariaForm';
+import { useNavigate } from 'react-router-dom';
+
+describe('CadastroBeneficiaria page', () => {
+  const useBeneficiariaFormMock = vi.mocked(useBeneficiariaForm);
+  const useNavigateMock = vi.mocked(useNavigate);
+
+  const createHookReturn = () => ({
+    formData: {
+      nome_completo: '',
+      cpf: '',
+      rg: '',
+      orgao_emissor_rg: '',
+      data_emissao_rg: '',
+      data_nascimento: '',
+      endereco: '',
+      bairro: '',
+      cep: '',
+      cidade: '',
+      estado: '',
+      nis: '',
+      contato1: '',
+      contato2: '',
+      referencia: '',
+      data_inicio_instituto: '2024-01-01',
+      programa_servico: '',
+    },
+    fieldErrors: {},
+    error: null,
+    success: false,
+    successMessage: null,
+    loading: false,
+    loadingCEP: false,
+    cepError: null,
+    handleInputChange: vi.fn(),
+    onBlurValidate: vi.fn(),
+    handleSubmit: vi.fn(),
+    handleCepBlur: vi.fn(),
+  });
+
+  let hookReturn: ReturnType<typeof createHookReturn>;
+  let navigateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hookReturn = createHookReturn();
+    navigateMock = vi.fn();
+    useBeneficiariaFormMock.mockReturnValue(hookReturn as any);
+    useNavigateMock.mockReturnValue(navigateMock as any);
+  });
+
+  it('renders layout and calls submit handler', () => {
+    const { container } = render(<CadastroBeneficiaria />);
+
+    expect(screen.getByText('Nova Beneficiária')).toBeInTheDocument();
+
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    expect(hookReturn.handleSubmit).toHaveBeenCalled();
+    expect(useBeneficiariaForm).toHaveBeenCalledWith(expect.objectContaining({ onSuccess: expect.any(Function) }));
+  });
+
+  it('propagates input changes to hook handlers', () => {
+    render(<CadastroBeneficiaria />);
+
+    fireEvent.change(screen.getByLabelText('Nome Completo *'), { target: { value: 'Fulana' } });
+    expect(hookReturn.handleInputChange).toHaveBeenCalledWith('nome_completo', 'Fulana');
+
+    fireEvent.blur(screen.getByLabelText('CPF *'), { target: { value: '123.456.789-01' } });
+    expect(hookReturn.onBlurValidate).toHaveBeenCalledWith('cpf', '123.456.789-01');
+  });
+
+  it('shows messages based on hook state', () => {
+    const navigate = vi.fn();
+    useNavigateMock.mockReturnValue(navigate as any);
+    useBeneficiariaFormMock.mockReturnValue({
+      ...hookReturn,
+      success: true,
+      successMessage: 'Tudo certo',
+    } as any);
+
+    render(<CadastroBeneficiaria />);
+
+    expect(screen.getByTestId('success-message')).toHaveTextContent('Tudo certo');
+    fireEvent.click(screen.getByTestId('voltar-lista'));
+    expect(navigate).toHaveBeenCalledWith('/beneficiarias');
+  });
+
+  it('displays error alert when hook sets error', () => {
+    useBeneficiariaFormMock.mockReturnValue({
+      ...hookReturn,
+      error: 'Erro ao salvar',
+    } as any);
+
+    render(<CadastroBeneficiaria />);
+
+    expect(screen.getByTestId('error-message')).toHaveTextContent('Erro ao salvar');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a dedicated `useBeneficiariaForm` hook that encapsulates field state, validation, CEP lookup, and mutation submission through `useCreateBeneficiaria`
- refactor the `CadastroBeneficiaria` page to consume the new hook and keep the component focused on rendering concerns
- add unit tests that cover the new hook's transformations and the page's interaction flow

## Testing
- npm run test:frontend *(fails: repository has pre-existing merge-conflict markers in apps/frontend/src/hooks/useAuth.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d978ad9fc883248e61f89f848d77eb