### PR TITLE
Add CSRF middleware globally with signed cookies

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -13,6 +13,7 @@ import { logger } from './services/logger';
 import { pool } from './config/database';
 import { env } from './config/env';
 import { applySecurityMiddleware } from './middleware/security.middleware';
+import { csrfMiddleware } from './middleware/csrf';
 
 const app: Express = express();
 const server = createServer(app);
@@ -29,6 +30,10 @@ if (env.ENABLE_WS) {
 
 // Middleware de segurança e sanitização
 applySecurityMiddleware(app);
+
+// Parsing e assinatura de cookies antes dos handlers
+app.use(cookieParser(env.JWT_SECRET));
+app.use(csrfMiddleware);
 
 // Logging
 app.use(morgan('combined', { stream: { write: (message) => logger.info(message.trim()) } }));

--- a/apps/backend/src/types/modules.d.ts
+++ b/apps/backend/src/types/modules.d.ts
@@ -6,3 +6,4 @@ declare module 'xss-clean';
 declare module 'xss-clean/lib/xss';
 declare module 'hpp';
 declare module 'factory-girl';
+declare module 'cookie-parser';


### PR DESCRIPTION
## Summary
- register the CSRF middleware globally after applying security middleware, ensuring cookies are parsed and signed ahead of mutable routes
- update the CSRF middleware to rely on cookie-parser, sign issued tokens and keep backward compatibility with legacy unsigned cookies
- expand CSRF middleware tests to cover the token endpoint, signed cookie flow and legacy token handling, and declare the cookie-parser module for TypeScript

## Testing
- npm run test:backend *(fails: existing TypeScript errors in unrelated suites)*
- npm test -- --runTestsByPath src/__tests__/csrf.middleware.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d978ac307883248dcc7b599e161401