### PR TITLE
Fix auth service refresh token handling

### DIFF
--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -56,11 +56,6 @@ interface RefreshRequestBody {
   deviceId?: string;
 }
 
-interface LogoutRequestBody {
-  refreshToken?: string;
-  deviceId?: string;
-}
-
 const allowedSameSite = ['lax', 'strict', 'none'] as const;
 type SameSiteOption = (typeof allowedSameSite)[number];
 
@@ -126,13 +121,7 @@ const loginHandler: RequestHandler<
 
     await clearLoginAttempts(req.body.email);
     setAuthCookie(res, result.token);
-<<<<<<< HEAD
     setRefreshCookie(res, result.refreshToken);
-=======
-    if (result.refreshToken) {
-      setRefreshCookie(res, result.refreshToken);
-    }
->>>>>>> main
     res.json({
       message: 'Login realizado com sucesso',
       token: result.token,
@@ -228,31 +217,6 @@ const changePasswordHandler: RequestHandler<
   }
 };
 
-const logoutHandler: RequestHandler<
-  EmptyParams,
-  { message: string } | { error: string },
-  LogoutRequestBody
-> = async (req, res) => {
-  const providedToken = req.body?.refreshToken;
-  const refreshToken = providedToken ?? getCookieValue(req.headers.cookie, 'refresh_token');
-  const deviceId = req.body?.deviceId ?? null;
-  const userAgent = req.get('user-agent') || null;
-
-  if (refreshToken) {
-    try {
-      await authService.revokeRefreshToken(refreshToken, { deviceId, userAgent });
-    } catch (error) {
-      loggerService.warn('Falha ao revogar refresh token no logout', {
-        error: error instanceof Error ? error.message : String(error)
-      });
-    }
-  }
-
-  clearAuthCookie(res);
-  clearRefreshCookie(res);
-  res.json({ message: 'Logout realizado com sucesso' });
-};
-
 /**
  * Retorna os dados de perfil do usuário autenticado.
  */
@@ -288,7 +252,6 @@ const refreshHandler: RequestHandler<
   RefreshRequestBody
 > = async (req, res) => {
   try {
-<<<<<<< HEAD
     const refreshToken = getCookieValue(req, 'refresh_token');
 
     if (!refreshToken) {
@@ -309,53 +272,6 @@ const refreshHandler: RequestHandler<
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Erro ao renovar token';
     res.status(401).json({ error: message });
-=======
-    const providedToken = req.body?.refreshToken;
-    const refreshToken = providedToken ?? getCookieValue(req.headers.cookie, 'refresh_token');
-
-    if (!refreshToken) {
-      res.status(400).json({ error: 'Refresh token é obrigatório' });
-      return;
-    }
-
-    const userAgent = req.get('user-agent') || null;
-    const ipAddress = req.ip || req.socket.remoteAddress || 'unknown';
-    const deviceId = req.body?.deviceId ?? null;
-
-    const result = await authService.renewAccessToken(refreshToken, {
-      deviceId,
-      userAgent,
-      ipAddress
-    });
-
-    setAuthCookie(res, result.token);
-    if (result.refreshToken) {
-      setRefreshCookie(res, result.refreshToken);
-    }
-
-    const role = result.user.papel ?? (result.user as { role?: string }).role ?? '';
-
-    res.json({
-      message: 'Token renovado',
-      token: result.token,
-      refreshToken: result.refreshToken,
-      user: {
-        id: result.user.id,
-        email: result.user.email,
-        role
-      }
-    });
-  } catch (error) {
-    if (error instanceof Error) {
-      loggerService.warn('Falha ao renovar token com refresh', {
-        error: error.message
-      });
-      res.status(401).json({ error: 'Refresh token inválido ou expirado' });
-      return;
-    }
-
-    handleUnexpectedError(res, error, 'Erro ao renovar token');
->>>>>>> main
   }
 };
 
@@ -367,7 +283,6 @@ router.post(
   loginHandler
 );
 router.post('/register', validateRequest(registerSchema), registerHandler);
-<<<<<<< HEAD
 router.post('/logout', async (req, res) => {
   const refreshToken = getCookieValue(req, 'refresh_token');
   if (refreshToken) {
@@ -385,11 +300,6 @@ router.post('/logout', async (req, res) => {
 });
 router.post('/refresh', refreshHandler);
 router.post('/refresh-token', refreshHandler);
-=======
-router.post('/logout', logoutHandler);
-router.post('/refresh', validateRequest(refreshTokenSchema), refreshHandler);
-router.post('/refresh-token', validateRequest(refreshTokenSchema), refreshHandler);
->>>>>>> main
 router.get('/profile', authenticateToken, profileHandler);
 router.get('/me', authenticateToken, profileHandler);
 router.put('/profile', authenticateToken, validateRequest(updateProfileSchema), updateProfileHandler);
@@ -409,21 +319,13 @@ function setRefreshCookie(res: Response, token: string): void {
   try {
     res.cookie('refresh_token', token, REFRESH_COOKIE_OPTIONS);
   } catch (error) {
-<<<<<<< HEAD
     loggerService.warn('Não foi possível definir cookie de refresh token', {
-=======
-    loggerService.warn('Não foi possível definir cookie de refresh', {
->>>>>>> main
       error: error instanceof Error ? error.message : String(error)
     });
   }
 }
 
-<<<<<<< HEAD
 function clearSessionCookies(res: Response): void {
-=======
-function clearAuthCookie(res: Response): void {
->>>>>>> main
   res.clearCookie('auth_token', COOKIE_OPTIONS);
   res.clearCookie('refresh_token', REFRESH_COOKIE_OPTIONS);
 }
@@ -469,25 +371,6 @@ function normalizeSameSite(value?: string | null): SameSiteOption | undefined {
 
   const normalized = value.toLowerCase() as SameSiteOption;
   return allowedSameSite.includes(normalized) ? normalized : undefined;
-}
-
-function getCookieValue(cookieHeader: string | undefined, name: string): string | undefined {
-  if (!cookieHeader) {
-    return undefined;
-  }
-
-  const cookies = cookieHeader
-    .split(';')
-    .map((cookie) => cookie.trim())
-    .filter(Boolean);
-
-  const target = cookies.find((cookie) => cookie.startsWith(`${name}=`));
-  if (!target) {
-    return undefined;
-  }
-
-  const [, value] = target.split('=');
-  return value ? decodeURIComponent(value) : undefined;
 }
 
 export default router;


### PR DESCRIPTION
## Summary
- consolidate the auth service import list and add a flag to track refresh token table initialization
- clean up the login flow to keep the JWT refresh token value and adjust parsing/revocation helpers
- restore the legacy auth routes implementation and remove merge conflict artefacts

## Testing
- `npm --prefix apps/backend run lint`
- `npm --prefix apps/backend run test` *(fails: existing TypeScript issues in unrelated controllers/routes)*

------
https://chatgpt.com/codex/tasks/task_e_68d978a4ba208324bac52d08008648ea