### PR TITLE
Fix auth logout storage cleanup

### DIFF
--- a/apps/frontend/src/hooks/useAuth.tsx
+++ b/apps/frontend/src/hooks/useAuth.tsx
@@ -84,38 +84,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       setLoading(true);
       const response = await authService.login({ email, password });
-      
+
       // Tipagem explícita do retorno esperado
       type LoginResponse = { token: string; refreshToken: string; user?: User };
       const resp = response as LoginResponse;
-      
-      // Armazenar token de acesso
+
+      // Armazenar token de acesso e limpar chaves legadas
       if (resp.token) {
         localStorage.setItem(AUTH_TOKEN_KEY, resp.token);
-        // Limpar chaves legadas
-        if (AUTH_TOKEN_KEY !== 'auth_token') {
-          localStorage.removeItem('auth_token');
-        }
-        if (AUTH_TOKEN_KEY !== 'token') {
-          localStorage.removeItem('token');
-        }
+        ["auth_token", "token"]
+          .filter((key) => key !== AUTH_TOKEN_KEY)
+          .forEach((legacyKey) => localStorage.removeItem(legacyKey));
       }
       if (resp.user) {
         localStorage.setItem(USER_KEY, JSON.stringify(resp.user));
-        if (USER_KEY !== 'user') {
-          localStorage.removeItem('user');
+        if (USER_KEY !== "user") {
+          localStorage.removeItem("user");
         }
         setUser(resp.user);
-=======
-      const accessToken = response.token ?? response.accessToken ?? null;
-      if (accessToken) {
-        localStorage.setItem('auth_token', accessToken);
-        localStorage.setItem('token', accessToken);
-      }
-      if (response.user) {
-        localStorage.setItem('user', JSON.stringify(response.user));
-        setUser(response.user);
->>>>>>> main
       }
       return {};
     } catch (error) {
@@ -130,20 +116,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       await authService.logout();
     } finally {
-<<<<<<< HEAD
-      const tokenKeys = new Set([
-        'token',
-        'auth_token',
-        AUTH_TOKEN_KEY
-      ]);
+      const tokenKeys = new Set(["token", "auth_token", AUTH_TOKEN_KEY]);
       tokenKeys.forEach((key) => localStorage.removeItem(key));
-      localStorage.removeItem('user');
       localStorage.removeItem(USER_KEY);
-=======
-      localStorage.removeItem("auth_token");
-      localStorage.removeItem("token");
-      localStorage.removeItem("user");
->>>>>>> main
+      if (USER_KEY !== "user") {
+        localStorage.removeItem("user");
+      }
       setUser(null);
       setLoading(false);
     }

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -82,16 +82,7 @@ export class AuthService {
   }
 
   async logout(): Promise<void> {
-    const tokenKeys = new Set([
-      AUTH_TOKEN_KEY,
-      'auth_token',
-      'token'
-    ]);
-    const userKeys = new Set([
-      USER_KEY,
-      'user'
-    ]);
-
+    const tokenKeys = new Set([AUTH_TOKEN_KEY, 'auth_token', 'token']);
     try {
       const deviceId = this.getDeviceId();
       await api.post(
@@ -103,7 +94,7 @@ export class AuthService {
       console.error('Erro ao fazer logout:', error);
     } finally {
       tokenKeys.forEach((key) => localStorage.removeItem(key));
-      userKeys.forEach((key) => localStorage.removeItem(key));
+      localStorage.removeItem(USER_KEY);
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve lingering merge conflict markers in the auth hook and service
- streamline logout cleanup to clear legacy token keys with a single Set and remove the stored user key
- ensure login and logout pathways synchronise storage updates after awaiting the API response

## Testing
- npm --prefix apps/frontend run lint *(fails: prettier --check reports formatting issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68d978a2443c832489ea08f9d518fbad