### PR TITLE
docs: add frontend url env variable to backend template

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ assist-move-assist/
 
    ```env
    PORT=3000
+   FRONTEND_URL=http://localhost:5173
    POSTGRES_HOST=localhost
    POSTGRES_USER=assistmove
    POSTGRES_PASSWORD=assistmove123

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,6 +1,7 @@
 # Servidor
 PORT=3000
 NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
 
 # Segurança
 JWT_SECRET=sua-chave-secreta-jwt


### PR DESCRIPTION
## Summary
- add the missing FRONTEND_URL default to the backend `.env.example`
- mention the new backend variable in the environment setup section of the README

## Testing
- npm --prefix apps/backend run type-check *(fails: existing merge conflict markers in src/routes/auth.routes.ts and src/services/auth.service.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d97899fa1083249b1d7b8405fb618f