### PR TITLE
test: type auth proxy as Pool in integration test

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.routes.integration.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.routes.integration.test.ts
@@ -37,7 +37,7 @@ jest.mock('../../config/database', () => {
     }
   };
 
-  const proxy = new Proxy({}, handler);
+  const proxy = new Proxy({} as Pool, handler);
 
   const execute = async (text: string, params?: any[]) => {
     if (!testPool) {


### PR DESCRIPTION
## Summary
- type the auth integration test's database proxy target as a `Pool` instance to preserve typings when forwarding calls

## Testing
- RUN_INTEGRATION=1 npm test -- src/routes/__tests__/auth.routes.integration.test.ts *(fails: Could not find a working container runtime strategy)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ba7bb9d48324af956b2013491060