### PR TITLE
Update auth security test limits

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -56,7 +56,9 @@ describe('POST /auth/login security middlewares', () => {
 
     const dbQuerySpy = jest.spyOn(db, 'query').mockResolvedValue([]);
 
-    for (let attempt = 0; attempt < 5; attempt += 1) {
+    const maxAttempts = (loginRateLimiter as any).options?.max ?? 5;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
       const response = await request(app)
         .post('/auth/login')
         .send({ email: 'user@example.com', password: 'wrong-password' });
@@ -70,7 +72,7 @@ describe('POST /auth/login security middlewares', () => {
 
     expect(blockedResponse.status).toBe(429);
     expect(blockedResponse.body.error).toContain('Muitas tentativas de login');
-    expect(recordMock).toHaveBeenCalledTimes(5);
+    expect(recordMock).toHaveBeenCalledTimes(maxAttempts);
 
     dbQuerySpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- update the auth security rate limiter test to read the configured max attempts before asserting responses
- keep the recorded attempts expectation in sync with the limiter configuration

## Testing
- npm test -- auth.security.routes.test.ts *(fails: existing TypeScript errors in src/routes/auth.routes.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bde3cab88324b295f994b88709b3