### PR TITLE
Ensure login rate limiter is enabled during auth security tests

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -1,6 +1,8 @@
 import request from 'supertest';
 import express from 'express';
 
+const originalEnableLoginRateLimit = process.env.ENABLE_LOGIN_RATE_LIMIT;
+
 jest.mock('../../middleware/auth', () => ({
   authenticateToken: jest.fn((_req: any, _res: any, next: any) => next()),
   requireProfissional: jest.fn(),
@@ -44,9 +46,17 @@ const resetRateLimiter = () => {
 };
 
 describe('POST /auth/login security middlewares', () => {
+  beforeAll(() => {
+    process.env.ENABLE_LOGIN_RATE_LIMIT = '1';
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     resetRateLimiter();
+  });
+
+  afterAll(() => {
+    process.env.ENABLE_LOGIN_RATE_LIMIT = originalEnableLoginRateLimit;
   });
 
   it('should limit excessive login attempts', async () => {


### PR DESCRIPTION
## Summary
- ensure the auth security route tests enable the login rate limiter by default and restore the prior configuration afterwards

## Testing
- npm --prefix apps/backend test *(fails: existing TypeScript errors in other test suites unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c0a8ff0c832493c85c97e9c69c5f