### PR TITLE
Expose planos de ação routes on API router

### DIFF
--- a/apps/backend/src/routes/api.ts
+++ b/apps/backend/src/routes/api.ts
@@ -39,6 +39,7 @@ import feedRoutes from './feed.routes';
 import declaracoesRoutes from './declaracoes.routes';
 import recibosRoutes from './recibos.routes';
 import formulariosRoutes from './formularios.routes';
+import planoAcaoRoutes from './planoAcao.routes';
 
 // Rotas de health check
 import healthRoutes from './health.routes';
@@ -113,6 +114,7 @@ router.use('/validation', validationRoutes);
 router.use('/projetos', projetosRoutes);
 router.use('/oficinas', oficinasRoutes);
 router.use('/participacoes', participacoesRoutes);
+router.use('/planos-acao', planoAcaoRoutes);
 router.use('/matriculas-projetos', matriculasRoutes);
 
 // 4. Rotas de conteúdo e comunicação
@@ -158,6 +160,7 @@ router.get('/', (req: ExpressRequest, res: ExpressResponse) => {
       projetos: '/api/projetos',
       oficinas: '/api/oficinas',
       participacoes: '/api/participacoes',
+      planosAcao: '/api/planos-acao',
       
       // Conteúdo
       feed: '/api/feed',


### PR DESCRIPTION
## Summary
- import the Plano de Ação router alongside other form endpoints
- register the `/planos-acao` route within the business section of the API router
- expose the new endpoint in the root API metadata response

## Testing
- TS_JEST_IGNORE_COMPILER_ERRORS=true npm test -- --runTestsByPath tests/api.test.ts --testPathIgnorePatterns="" *(fails: TypeScript compilation errors inside tests/api.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c327666c8324955b711e4cb6dff3