### PR TITLE
Align backend tests with enveloped API responses

### DIFF
--- a/apps/backend/tests/beneficiarias.test.ts
+++ b/apps/backend/tests/beneficiarias.test.ts
@@ -54,29 +54,33 @@ describe('Beneficiarias API Tests', () => {
           .set('Authorization', `Bearer ${authToken}`)
       )
     ).send(beneficiaria);
-    
+
     expect(res.status).toBe(201);
-    expect(res.body).toHaveProperty('id');
-    beneficiariaId = res.body.id;
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('id');
+    beneficiariaId = res.body.data.id;
   });
 
   it('should get beneficiaria by id', async () => {
     const res = await request(app)
       .get(`/api/beneficiarias/${beneficiariaId}`)
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('id', beneficiariaId);
-    expect(res.body.nome).toBe('Maria Teste');
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('id', beneficiariaId);
+    expect(res.body.data.nome).toBe('Maria Teste');
   });
 
   it('should list beneficiarias', async () => {
     const res = await request(app)
       .get('/api/beneficiarias')
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.success).toBe(true);
+    const items = res.body.data?.items ?? res.body.data?.data ?? res.body.data;
+    expect(Array.isArray(items)).toBe(true);
   });
 
   it('should update beneficiaria', async () => {
@@ -88,13 +92,14 @@ describe('Beneficiarias API Tests', () => {
       await withCsrf(
         app,
         request(app)
-          .patch(`/api/beneficiarias/${beneficiariaId}`)
+          .put(`/api/beneficiarias/${beneficiariaId}`)
           .set('Authorization', `Bearer ${authToken}`)
       )
     ).send(update);
-    
+
     expect(res.status).toBe(200);
-    expect(res.body.telefone).toBe(update.telefone);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.telefone).toBe(update.telefone);
   });
 
   it('should require auth for beneficiarias endpoints', async () => {

--- a/apps/backend/tests/feed.test.ts
+++ b/apps/backend/tests/feed.test.ts
@@ -44,29 +44,33 @@ describe('Feed Posts API Tests', () => {
           .set('Authorization', `Bearer ${authToken}`)
       )
     ).send(post);
-    
+
     expect(res.status).toBe(201);
-    expect(res.body).toHaveProperty('id');
-    postId = res.body.id;
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('id');
+    postId = res.body.data.id;
   });
 
   it('should list feed posts', async () => {
     const res = await request(app)
       .get('/api/feed')
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.success).toBe(true);
+    const items = res.body.data?.items ?? res.body.data?.data ?? res.body.data;
+    expect(Array.isArray(items)).toBe(true);
   });
 
   it('should get feed post by id', async () => {
     const res = await request(app)
       .get(`/api/feed/${postId}`)
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('id', postId);
-    expect(res.body.titulo).toBe('Post de Teste');
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('id', postId);
+    expect(res.body.data.titulo).toBe('Post de Teste');
   });
 
   it('should update feed post', async () => {
@@ -78,13 +82,14 @@ describe('Feed Posts API Tests', () => {
       await withCsrf(
         app,
         request(app)
-          .patch(`/api/feed/${postId}`)
+          .put(`/api/feed/${postId}`)
           .set('Authorization', `Bearer ${authToken}`)
       )
     ).send(update);
-    
+
     expect(res.status).toBe(200);
-    expect(res.body.titulo).toBe(update.titulo);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.titulo).toBe(update.titulo);
   });
 
   it('should filter feed posts by type', async () => {
@@ -92,10 +97,12 @@ describe('Feed Posts API Tests', () => {
       .get('/api/feed')
       .query({ tipo: 'NOTICIA' })
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.every((post: any) => post.tipo === 'NOTICIA')).toBe(true);
+    expect(res.body.success).toBe(true);
+    const items = res.body.data?.items ?? res.body.data?.data ?? res.body.data;
+    expect(Array.isArray(items)).toBe(true);
+    expect(items.every((post: any) => post.tipo === 'NOTICIA')).toBe(true);
   });
 
   it('should require auth for feed posts endpoints', async () => {

--- a/apps/backend/tests/oficinas.test.ts
+++ b/apps/backend/tests/oficinas.test.ts
@@ -42,18 +42,21 @@ describe('Oficinas API Tests', () => {
           .set('Authorization', `Bearer ${authToken}`)
       )
     ).send(oficina);
-    
+
     expect(res.status).toBe(201);
-    expect(res.body).toHaveProperty('id');
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveProperty('id');
   });
 
   it('should list oficinas', async () => {
     const res = await request(app)
       .get('/api/oficinas')
       .set('Authorization', `Bearer ${authToken}`);
-    
+
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.success).toBe(true);
+    const items = res.body.data?.items ?? res.body.data?.data ?? res.body.data;
+    expect(Array.isArray(items)).toBe(true);
   });
 
   it('should require auth for oficinas endpoints', async () => {


### PR DESCRIPTION
## Summary
- update feed, beneficiarias and oficinas tests to assert the success flag and read data from the response envelope
- adjust update calls to use PUT where the API exposes only PUT handlers
- read list payloads from the enveloped data structure to cover pagination metadata

## Testing
- npm run test:integration *(fails: TypeError: ansiRegex is not a function in strip-ansi used by jest reporters)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c4155e7883248b3ee474959285a7