### PR TITLE
Atualiza modelo do Plano de Ação para refletir hydratePlano

### DIFF
--- a/apps/backend/src/models/PlanoAcao.ts
+++ b/apps/backend/src/models/PlanoAcao.ts
@@ -1,26 +1,36 @@
+export type PlanoAcaoItemStatus = 'pendente' | 'em_andamento' | 'concluida' | 'cancelada';
+
+export interface PlanoAcaoItem {
+  id: number;
+  titulo: string;
+  responsavel: string | null;
+  prazo: string | null;
+  status: PlanoAcaoItemStatus;
+  suporte_oferecido: string | null;
+  criado_em: string | null;
+  atualizado_em: string | null;
+}
+
 export interface PlanoAcao {
   id: number;
   beneficiaria_id: number;
-  data_plano: Date;
+  criado_por: number | null;
+  criado_em: string | null;
+  atualizado_em: string | null;
   objetivo_principal: string;
   areas_prioritarias: string[];
-  outras_areas?: string[];
-  acoes_realizadas: string[];
-  suporte_instituto?: string;
-  primeira_avaliacao_data?: Date;
-  primeira_avaliacao_progresso?: string;
-  segunda_avaliacao_data?: Date;
-  segunda_avaliacao_progresso?: string;
-  assinatura_beneficiaria: boolean;
-  assinatura_responsavel_tecnico: boolean;
-  data_criacao: Date;
-  data_atualizacao?: Date;
+  observacoes: string | null;
+  primeira_avaliacao_em: string | null;
+  primeira_avaliacao_nota: string | null;
+  segunda_avaliacao_em: string | null;
+  segunda_avaliacao_nota: string | null;
+  assinatura_beneficiaria: string | null;
+  assinatura_responsavel: string | null;
+  itens: PlanoAcaoItem[];
 }
-
-export type PlanoAcaoInput = Omit<PlanoAcao, 'id' | 'data_criacao' | 'data_atualizacao'>;
 
 export interface PlanoAcaoResponse {
   data?: PlanoAcao | PlanoAcao[];
   error?: string;
-  message?: string;
+  detalhes?: unknown;
 }


### PR DESCRIPTION
## Summary
- atualiza a interface PlanoAcao para refletir o payload retornado por hydratePlano, incluindo campos de auditoria e coleção de itens tipada
- adiciona tipos auxiliares para os itens do plano e ajusta PlanoAcaoResponse para remover propriedades obsoletas

## Testing
- npm run build *(falhou: erros de TypeScript preexistentes em controllers, middlewares e rotas)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c522f77483248f3a41af4ba9d44c