### PR TITLE
feat(frontend): centralize CSRF token handling

### DIFF
--- a/apps/frontend/src/services/auth.service.test.ts
+++ b/apps/frontend/src/services/auth.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import api from '@/config/api';
 import { AuthService } from './auth.service';
+import { clearCsrfToken, getCsrfToken } from './csrfTokenStore';
 
 describe('AuthService', () => {
   const authService = AuthService.getInstance();
@@ -8,6 +9,8 @@ describe('AuthService', () => {
   beforeEach(() => {
     localStorage.clear();
     document.cookie = 'csrf_token=; Max-Age=0; path=/';
+    clearCsrfToken();
+    delete (api.defaults.headers.common as any)['X-CSRF-Token'];
   });
 
   afterEach(() => {
@@ -18,7 +21,9 @@ describe('AuthService', () => {
     const getDeviceIdSpy = vi
       .spyOn(authService as unknown as { getDeviceId: () => string }, 'getDeviceId')
       .mockReturnValue('test-device-id');
-    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({} as any);
+    const getSpy = vi
+      .spyOn(api, 'get')
+      .mockResolvedValue({ data: { csrfToken: 'csrf-123' } } as any);
     const expectedResponse = {
       token: 'token123',
       refreshToken: 'refresh123',
@@ -44,6 +49,8 @@ describe('AuthService', () => {
     );
     expect(result).toEqual(expectedResponse);
     expect(getDeviceIdSpy).toHaveBeenCalled();
+    expect(getCsrfToken()).toBe('csrf-123');
+    expect(api.defaults.headers.common['X-CSRF-Token']).toBe('csrf-123');
   });
 
   it('should fallback to legacy CSRF endpoint when primary request fails', async () => {
@@ -53,7 +60,7 @@ describe('AuthService', () => {
     const getSpy = vi
       .spyOn(api, 'get')
       .mockRejectedValueOnce(new Error('not found'))
-      .mockResolvedValueOnce({} as any);
+      .mockResolvedValueOnce({ data: { csrfToken: 'legacy-token' } } as any);
     const postSpy = vi.spyOn(api, 'post').mockResolvedValue({ data: { token: 'a', refreshToken: 'b', user: { id: 1, email: '', nome: '', papel: '' } } } as any);
 
     await authService.login({ email: 'a', password: 'b' });
@@ -62,6 +69,15 @@ describe('AuthService', () => {
     expect(getSpy.mock.calls[0]).toEqual(['/csrf-token', { withCredentials: true }]);
     expect(getSpy.mock.calls[1]).toEqual(['/auth/csrf', { withCredentials: true }]);
     expect(postSpy).toHaveBeenCalled();
+    expect(getCsrfToken()).toBe('legacy-token');
+  });
+
+  it('should throw when no CSRF token can be retrieved', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ data: {} } as any);
+
+    await expect(authService.login({ email: 'user@example.com', password: 'secret' })).rejects.toThrow(
+      /token CSRF/i
+    );
   });
 
   it('should remove stored tokens after logout', async () => {
@@ -74,7 +90,7 @@ describe('AuthService', () => {
     const getDeviceIdSpy = vi
       .spyOn(authService as unknown as { getDeviceId: () => string }, 'getDeviceId')
       .mockReturnValue('test-device-id');
-    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({} as any);
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ data: { csrfToken: 'logout-token' } } as any);
     const postSpy = vi.spyOn(api, 'post').mockResolvedValue({} as any);
 
     await authService.logout();
@@ -91,13 +107,14 @@ describe('AuthService', () => {
     expect(localStorage.getItem('token')).toBeNull();
     expect(localStorage.getItem('test_user')).toBeNull();
     expect(localStorage.getItem('user')).toBeNull();
+    expect(api.defaults.headers.common['X-CSRF-Token']).toBe('logout-token');
   });
 
   it('should fetch csrf token before refreshing token', async () => {
     vi
       .spyOn(authService as unknown as { getDeviceId: () => string }, 'getDeviceId')
       .mockReturnValue('device-refresh');
-    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({} as any);
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ data: { csrfToken: 'refresh-token' } } as any);
     const responsePayload = {
       message: 'ok',
       token: 'token',
@@ -115,5 +132,6 @@ describe('AuthService', () => {
       { withCredentials: true }
     );
     expect(result).toEqual(responsePayload);
+    expect(getCsrfToken()).toBe('refresh-token');
   });
 });

--- a/apps/frontend/src/services/csrfTokenStore.ts
+++ b/apps/frontend/src/services/csrfTokenStore.ts
@@ -1,0 +1,42 @@
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+let csrfToken: string | null = null;
+
+export function getCsrfToken(): string | null {
+  return csrfToken;
+}
+
+export function setCsrfToken(token: string | null): void {
+  csrfToken = token;
+}
+
+export function clearCsrfToken(): void {
+  csrfToken = null;
+}
+
+export function applyCsrfTokenToAxios(instance: AxiosInstance): void {
+  if (!instance?.defaults?.headers) {
+    return;
+  }
+
+  if (csrfToken) {
+    instance.defaults.headers.common = instance.defaults.headers.common ?? {};
+    instance.defaults.headers.common['X-CSRF-Token'] = csrfToken;
+  } else if (instance.defaults.headers.common) {
+    delete instance.defaults.headers.common['X-CSRF-Token'];
+  }
+}
+
+export function applyCsrfTokenToConfig(config: AxiosRequestConfig): AxiosRequestConfig {
+  if (!config.headers) {
+    config.headers = {};
+  }
+
+  if (csrfToken) {
+    (config.headers as Record<string, unknown>)['X-CSRF-Token'] = csrfToken;
+  } else if ('X-CSRF-Token' in config.headers) {
+    delete (config.headers as Record<string, unknown>)['X-CSRF-Token'];
+  }
+
+  return config;
+}


### PR DESCRIPTION
## Summary
- capture CSRF tokens from the authentication service and cache them in a shared store that updates axios defaults
- reuse the shared CSRF token within the generic API service instead of reading cookies before mutating requests
- extend Vitest coverage for auth/api services to cover CSRF success and failure scenarios

## Testing
- npx vitest run src/services/auth.service.test.ts src/services/apiService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9cc9bbdfc832489ac91f3bf2160fc