### PR TITLE
Ensure API requests fetch CSRF tokens when missing

### DIFF
--- a/apps/frontend/src/services/csrf.service.ts
+++ b/apps/frontend/src/services/csrf.service.ts
@@ -1,0 +1,46 @@
+import type { AxiosInstance } from 'axios';
+import api from '@/config/api';
+import {
+  applyCsrfTokenToAxios,
+  getCsrfToken,
+  setCsrfToken,
+} from './csrfTokenStore';
+
+let csrfFetchPromise: Promise<string | null> | null = null;
+
+export async function ensureCsrfTokenFetched(
+  axiosInstance: AxiosInstance = api,
+  endpoint = '/csrf-token'
+): Promise<string | null> {
+  const existingToken = getCsrfToken();
+  if (existingToken) {
+    applyCsrfTokenToAxios(axiosInstance);
+    return existingToken;
+  }
+
+  if (!csrfFetchPromise) {
+    csrfFetchPromise = axiosInstance
+      .get<{ csrfToken?: string }>(endpoint, { withCredentials: true })
+      .then((response) => {
+        const csrfToken = response?.data?.csrfToken ?? null;
+        if (csrfToken) {
+          setCsrfToken(csrfToken);
+        }
+        return csrfToken;
+      })
+      .catch((error) => {
+        throw error;
+      })
+      .finally(() => {
+        csrfFetchPromise = null;
+      });
+  }
+
+  const token = await csrfFetchPromise;
+
+  if (token) {
+    applyCsrfTokenToAxios(axiosInstance);
+  }
+
+  return token;
+}


### PR DESCRIPTION
## Summary
- add a shared `ensureCsrfTokenFetched` helper that retrieves `/csrf-token` and updates the CSRF store
- reuse the shared helper in `AuthService` and load CSRF tokens in the API interceptor before mutating calls
- extend API service tests to cover token fetching and concurrent mutation scenarios

## Testing
- npx vitest run src/services/apiService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9d44f9c94832496f9d493e96b2c2a