### PR TITLE
Fix programa filter for beneficiarias listing

### DIFF
--- a/apps/frontend/src/types/shared/index.ts
+++ b/apps/frontend/src/types/shared/index.ts
@@ -43,6 +43,7 @@ export interface Beneficiaria {
     telefone: string;
     telefone_secundario?: string | null;
     email?: string | null;
+    programa_servico?: string | null;
     endereco?:
         | string
         | {

--- a/apps/frontend/src/utils/beneficiarias.test.ts
+++ b/apps/frontend/src/utils/beneficiarias.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { filterBeneficiarias } from './beneficiarias';
+import type { Beneficiaria } from '@/types/shared';
+
+describe('filterBeneficiarias', () => {
+  const createBeneficiaria = (
+    overrides: Partial<Beneficiaria> & { programa_servico: string }
+  ): Beneficiaria => ({
+    id: 1,
+    codigo: '001',
+    nome_completo: 'Beneficiária',
+    cpf: '12345678901',
+    data_nascimento: '2000-01-01',
+    telefone: '11999999999',
+    status: 'ativa',
+    programa_servico: overrides.programa_servico,
+    ...overrides,
+  });
+
+  it('retorna apenas beneficiárias do programa selecionado', () => {
+    const beneficiarias: Beneficiaria[] = [
+      createBeneficiaria({ id: 1, codigo: '001', programa_servico: 'Programa A', nome_completo: 'Ana' }),
+      createBeneficiaria({ id: 2, codigo: '002', programa_servico: 'Programa B', nome_completo: 'Beatriz' }),
+      createBeneficiaria({ id: 3, codigo: '003', programa_servico: 'Programa B', nome_completo: 'Bianca' }),
+    ];
+
+    const filtradas = filterBeneficiarias(beneficiarias, { programa: 'Programa B' });
+
+    expect(filtradas).toHaveLength(2);
+    expect(filtradas.map((b) => b.nome_completo)).toEqual(['Beatriz', 'Bianca']);
+  });
+});

--- a/apps/frontend/src/utils/beneficiarias.ts
+++ b/apps/frontend/src/utils/beneficiarias.ts
@@ -122,7 +122,11 @@ export const filterBeneficiarias = (
       paedi.includes(normalized);
 
     const matchesStatus = statusFilter === 'Todas' || statusDisplay === statusFilter;
-    const matchesPrograma = programaFilter === 'Todos' || !filters.programa;
+    const beneficiariaPrograma = beneficiaria.programa_servico?.toLowerCase() ?? '';
+    const matchesPrograma =
+      programaFilter === 'Todos' ||
+      !filters.programa ||
+      beneficiariaPrograma === programaFilter.toLowerCase();
 
     return matchesSearch && matchesStatus && matchesPrograma;
   });


### PR DESCRIPTION
## Summary
- update the beneficiaria filter utility to match `programa_servico` when a specific programa is selected
- add the `programa_servico` field to the `Beneficiaria` shared type
- cover filtering by programa with a new unit test

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68d9e18edd248324a7a8318dd8979d66