### PR TITLE
feat: extend beneficiarias endpoints

### DIFF
--- a/apps/backend/src/database/migrations/049_extend_beneficiarias_relations.sql
+++ b/apps/backend/src/database/migrations/049_extend_beneficiarias_relations.sql
@@ -1,0 +1,47 @@
+-- Amplia dados relacionados às beneficiárias: dependentes, informações socioeconômicas e foto
+
+ALTER TABLE beneficiarias
+  ADD COLUMN IF NOT EXISTS foto_filename TEXT,
+  ADD COLUMN IF NOT EXISTS arquivada_em TIMESTAMP NULL;
+
+CREATE TABLE IF NOT EXISTS beneficiaria_info_socioeconomica (
+  beneficiaria_id INTEGER PRIMARY KEY REFERENCES beneficiarias(id) ON DELETE CASCADE,
+  renda_familiar DECIMAL(10,2),
+  quantidade_moradores INTEGER,
+  tipo_moradia VARCHAR(120),
+  escolaridade VARCHAR(120),
+  profissao VARCHAR(120),
+  situacao_trabalho VARCHAR(120),
+  beneficios_sociais TEXT[] DEFAULT '{}',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+DROP TRIGGER IF EXISTS trg_beneficiaria_info_socioeconomica_updated_at ON beneficiaria_info_socioeconomica;
+CREATE TRIGGER trg_beneficiaria_info_socioeconomica_updated_at
+BEFORE UPDATE ON beneficiaria_info_socioeconomica
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE TABLE IF NOT EXISTS beneficiaria_dependentes (
+  id SERIAL PRIMARY KEY,
+  beneficiaria_id INTEGER NOT NULL REFERENCES beneficiarias(id) ON DELETE CASCADE,
+  nome_completo VARCHAR(255) NOT NULL,
+  data_nascimento DATE NOT NULL,
+  parentesco VARCHAR(120) NOT NULL,
+  cpf VARCHAR(11),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_beneficiaria_dependentes_beneficiaria
+  ON beneficiaria_dependentes(beneficiaria_id);
+
+DROP TRIGGER IF EXISTS trg_beneficiaria_dependentes_updated_at ON beneficiaria_dependentes;
+CREATE TRIGGER trg_beneficiaria_dependentes_updated_at
+BEFORE UPDATE ON beneficiaria_dependentes
+FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Registro mínimo para garantir consistência
+UPDATE beneficiarias
+SET updated_at = CURRENT_TIMESTAMP
+WHERE foto_filename IS NULL;

--- a/apps/backend/src/models/beneficiaria.ts
+++ b/apps/backend/src/models/beneficiaria.ts
@@ -2,5 +2,8 @@ export type {
   BeneficiariaStatus,
   BeneficiariaFamiliar,
   Beneficiaria,
-  BeneficiariaDetalhada
+  BeneficiariaDetalhada,
+  BeneficiariaInfoSocioeconomica,
+  BeneficiariaDependente,
+  BeneficiariaHistoricoAtendimento
 } from '../types/beneficiarias';

--- a/apps/backend/src/routes/beneficiarias.routes.ts
+++ b/apps/backend/src/routes/beneficiarias.routes.ts
@@ -1,4 +1,6 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, type RequestHandler } from 'express';
+import fs from 'fs';
+import path from 'path';
 // Import com case correto para compatibilidade em Linux (FS case-sensitive)
 import { BeneficiariasService } from '../services/beneficiarias.service';
 import { authenticateToken, requireProfissional, authorize } from '../middleware/auth';
@@ -7,16 +9,73 @@ import { formatObjectDates } from '../utils/dateFormatter';
 import { AppError } from '../utils';
 import { loggerService } from '../services/logger';
 import { validateRequest } from '../middleware/validationMiddleware';
-import { beneficiariaSchema, validateBeneficiaria } from '../validators/beneficiaria.validator';
+import {
+  atendimentoSchema,
+  beneficiariaSchema,
+  dependenteSchema,
+  infoSocioeconomicaSchema,
+  validateBeneficiaria
+} from '../validators/beneficiaria.validator';
 import { pool } from '../config/database';
 import { ZodError } from 'zod';
 import { redis } from '../lib/redis';
+import { uploadSingle, UPLOAD_DIR } from '../middleware/upload';
+import type { BeneficiariaDetalhada } from '../types/beneficiarias';
 
 // Interface para requisições autenticadas com parâmetros e corpo
 type ExtendedRequest = Request;
 
 const router = Router();
 const beneficiariasService = new BeneficiariasService(pool, redis);
+
+const uploadFotoMiddleware = (fieldName: string): RequestHandler => (
+  uploadSingle(fieldName) as unknown as RequestHandler
+);
+
+const formatBeneficiariaDetalhadaResponse = (
+  beneficiaria: BeneficiariaDetalhada
+): BeneficiariaDetalhada => {
+  const base = formatObjectDates(
+    beneficiaria as unknown as Record<string, unknown>,
+    ['data_nascimento', 'rg_data_emissao', 'created_at', 'updated_at', 'arquivada_em'] as any
+  ) as unknown as BeneficiariaDetalhada;
+
+  const familiaresFormatados =
+    base.familiares?.map((familiar) =>
+      formatObjectDates(familiar as unknown as Record<string, unknown>, ['data_nascimento', 'created_at'] as any)
+    ) ?? [];
+
+  const dependentesFormatados =
+    base.dependentes?.map((dependente) =>
+      formatObjectDates(
+        dependente as unknown as Record<string, unknown>,
+        ['data_nascimento', 'created_at', 'updated_at'] as any
+      )
+    ) ?? [];
+
+  const historicoFormatado =
+    base.historico_atendimentos?.map((atendimento) =>
+      formatObjectDates(
+        atendimento as unknown as Record<string, unknown>,
+        ['data', 'created_at', 'updated_at'] as any
+      )
+    ) ?? [];
+
+  const infoSocio = base.info_socioeconomica
+    ? formatObjectDates(
+        base.info_socioeconomica as unknown as Record<string, unknown>,
+        ['created_at', 'updated_at'] as any
+      )
+    : null;
+
+  return {
+    ...base,
+    familiares: familiaresFormatados as any,
+    dependentes: dependentesFormatados as any,
+    historico_atendimentos: historicoFormatado as any,
+    info_socioeconomica: infoSocio as any
+  };
+};
 
 // GET / - Listar beneficiárias (paginado)
 router.get(
@@ -95,19 +154,9 @@ router.get(
       const { id } = req.params;
       const beneficiaria = await beneficiariasService.getDetalhes(Number(id));
 
-      const beneficiariaFormatada = formatObjectDates(
-        beneficiaria as unknown as Record<string, unknown>,
-        ['data_nascimento', 'rg_data_emissao', 'created_at', 'updated_at'] as any
-      ) as unknown as typeof beneficiaria;
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
 
-      const familiaresFormatados = beneficiariaFormatada.familiares?.map((familiar) =>
-        formatObjectDates(familiar as unknown as Record<string, unknown>, ['data_nascimento'] as any)
-      ) ?? [];
-
-      res.json(successResponse({
-        ...beneficiariaFormatada,
-        familiares: familiaresFormatados
-      }));
+      res.json(successResponse(beneficiariaFormatada));
       return;
     } catch (error) {
       if (error instanceof AppError) {
@@ -218,23 +267,13 @@ router.post(
         skipValidation: true
       });
 
-      const beneficiariaFormatada = formatObjectDates(
-        beneficiaria as unknown as Record<string, unknown>,
-        ['data_nascimento', 'rg_data_emissao', 'created_at', 'updated_at'] as any
-      ) as unknown as typeof beneficiaria;
-
-      const familiaresFormatados = beneficiariaFormatada.familiares?.map((familiar) =>
-        formatObjectDates(familiar as unknown as Record<string, unknown>, ['data_nascimento'] as any)
-      ) ?? [];
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
 
       loggerService.audit('BENEFICIARIA_CREATED', (req as any).user?.id, {
         beneficiaria_id: beneficiaria.id
       });
 
-      res.status(201).json(successResponse({
-        ...beneficiariaFormatada,
-        familiares: familiaresFormatados
-      }));
+      res.status(201).json(successResponse(beneficiariaFormatada));
       return;
     } catch (error) {
       if (error instanceof ZodError) {
@@ -282,24 +321,14 @@ router.put(
         { skipValidation: true }
       );
 
-      const beneficiariaFormatada = formatObjectDates(
-        beneficiaria as unknown as Record<string, unknown>,
-        ['data_nascimento', 'rg_data_emissao', 'created_at', 'updated_at'] as any
-      ) as unknown as typeof beneficiaria;
-
-      const familiaresFormatados = beneficiariaFormatada.familiares?.map((familiar) =>
-        formatObjectDates(familiar as unknown as Record<string, unknown>, ['data_nascimento'] as any)
-      ) ?? [];
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
 
       loggerService.audit('BENEFICIARIA_UPDATED', (req as any).user?.id, {
         beneficiaria_id: id,
         changes: updateData
       });
 
-      res.json(successResponse({
-        ...beneficiariaFormatada,
-        familiares: familiaresFormatados
-      }));
+      res.json(successResponse(beneficiariaFormatada));
       return;
     } catch (error) {
       if (error instanceof ZodError) {
@@ -316,6 +345,274 @@ router.put(
       }
       loggerService.error('Update beneficiaria error:', error);
       res.status(500).json(errorResponse('Erro ao atualizar beneficiária'));
+      return;
+    }
+  }
+);
+
+router.patch(
+  '/:id/arquivar',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      await beneficiariasService.arquivarBeneficiaria(Number(id));
+
+      loggerService.audit('BENEFICIARIA_ARCHIVED', (req as any).user?.id, {
+        beneficiaria_id: id
+      });
+
+      res.json(successResponse<null>(null, 'Beneficiária arquivada com sucesso'));
+      return;
+    } catch (error) {
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao arquivar beneficiária:', error);
+      res.status(500).json(errorResponse('Erro ao arquivar beneficiária'));
+      return;
+    }
+  }
+);
+
+router.put(
+  '/:id/info-socioeconomica',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  validateRequest(
+    require('zod').z.object({
+      body: infoSocioeconomicaSchema,
+      query: require('zod').z.any().optional(),
+      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+    })
+  ),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const beneficiaria = await beneficiariasService.atualizarInfoSocioeconomica(
+        Number(id),
+        req.body
+      );
+
+      loggerService.audit('BENEFICIARIA_SOCIOECONOMICO_UPDATED', (req as any).user?.id, {
+        beneficiaria_id: id,
+        payload: req.body
+      });
+
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
+      res.json(successResponse(beneficiariaFormatada));
+      return;
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({
+          success: false,
+          message: 'Dados inválidos',
+          errors: error.issues
+        });
+        return;
+      }
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao atualizar informações socioeconômicas:', error);
+      res.status(500).json(errorResponse('Erro ao atualizar informações socioeconômicas'));
+      return;
+    }
+  }
+);
+
+router.post(
+  '/:id/dependentes',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  validateRequest(
+    require('zod').z.object({
+      body: dependenteSchema,
+      query: require('zod').z.any().optional(),
+      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+    })
+  ),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const beneficiaria = await beneficiariasService.adicionarDependente(Number(id), req.body);
+
+      loggerService.audit('BENEFICIARIA_DEPENDENTE_ADICIONADO', (req as any).user?.id, {
+        beneficiaria_id: id,
+        dependente: req.body?.nome_completo
+      });
+
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
+      res.status(201).json(successResponse(beneficiariaFormatada));
+      return;
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({
+          success: false,
+          message: 'Dados inválidos',
+          errors: error.issues
+        });
+        return;
+      }
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao adicionar dependente:', error);
+      res.status(500).json(errorResponse('Erro ao adicionar dependente'));
+      return;
+    }
+  }
+);
+
+router.delete(
+  '/:id/dependentes/:dependenteId',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    try {
+      const { id, dependenteId } = req.params as any;
+      await beneficiariasService.removerDependente(Number(id), Number(dependenteId));
+
+      loggerService.audit('BENEFICIARIA_DEPENDENTE_REMOVIDO', (req as any).user?.id, {
+        beneficiaria_id: id,
+        dependente_id: dependenteId
+      });
+
+      res.json(successResponse<null>(null, 'Dependente removido com sucesso'));
+      return;
+    } catch (error) {
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao remover dependente:', error);
+      res.status(500).json(errorResponse('Erro ao remover dependente'));
+      return;
+    }
+  }
+);
+
+router.post(
+  '/:id/atendimentos',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  validateRequest(
+    require('zod').z.object({
+      body: atendimentoSchema,
+      query: require('zod').z.any().optional(),
+      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+    })
+  ),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const beneficiaria = await beneficiariasService.adicionarAtendimento(Number(id), req.body);
+
+      loggerService.audit('BENEFICIARIA_ATENDIMENTO_ADICIONADO', (req as any).user?.id, {
+        beneficiaria_id: id,
+        tipo: req.body?.tipo
+      });
+
+      const beneficiariaFormatada = formatBeneficiariaDetalhadaResponse(beneficiaria);
+      res.status(201).json(successResponse(beneficiariaFormatada));
+      return;
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({
+          success: false,
+          message: 'Dados inválidos',
+          errors: error.issues
+        });
+        return;
+      }
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao registrar atendimento:', error);
+      res.status(500).json(errorResponse('Erro ao registrar atendimento'));
+      return;
+    }
+  }
+);
+
+router.post(
+  '/:id/foto',
+  authenticateToken,
+  requireProfissional,
+  authorize('beneficiarias.editar'),
+  uploadFotoMiddleware('foto'),
+  async (req: ExtendedRequest, res: Response): Promise<void> => {
+    const uploadedFile = (req as any).file as Express.Multer.File | undefined;
+    try {
+      const { id } = req.params;
+      const beneficiariaId = Number(id);
+
+      if (!uploadedFile) {
+        res.status(400).json(errorResponse('Nenhum arquivo enviado'));
+        return;
+      }
+
+      const existente = await beneficiariasService.buscarPorId(beneficiariaId);
+      const fotoAnterior = existente.foto_filename;
+
+      const beneficiariaAtualizada = await beneficiariasService.atualizarFoto(
+        beneficiariaId,
+        uploadedFile.filename
+      );
+
+      if (fotoAnterior && fotoAnterior !== beneficiariaAtualizada.foto_filename) {
+        const antigoPath = path.join(UPLOAD_DIR, fotoAnterior);
+        try {
+          await fs.promises.unlink(antigoPath);
+        } catch (unlinkError: any) {
+          if (unlinkError?.code !== 'ENOENT') {
+            loggerService.warn('Falha ao remover foto antiga da beneficiária', {
+              beneficiariaId,
+              error: unlinkError
+            });
+          }
+        }
+      }
+
+      loggerService.audit('BENEFICIARIA_FOTO_ATUALIZADA', (req as any).user?.id, {
+        beneficiaria_id: id,
+        filename: beneficiariaAtualizada.foto_filename
+      });
+
+      res.status(201).json(
+        successResponse({
+          foto_url: beneficiariaAtualizada.foto_url ?? null,
+          foto_filename: beneficiariaAtualizada.foto_filename ?? null
+        }, 'Foto atualizada com sucesso')
+      );
+      return;
+    } catch (error) {
+      if (uploadedFile) {
+        try {
+          await fs.promises.unlink(path.join(UPLOAD_DIR, uploadedFile.filename));
+        } catch (unlinkError) {
+          loggerService.warn('Falha ao remover upload após erro', {
+            error: unlinkError
+          });
+        }
+      }
+
+      if (error instanceof AppError) {
+        res.status(error.statusCode).json(errorResponse(error.message));
+        return;
+      }
+      loggerService.error('Erro ao atualizar foto da beneficiária:', error);
+      res.status(500).json(errorResponse('Erro ao atualizar foto da beneficiária'));
       return;
     }
   }

--- a/apps/backend/src/types/beneficiarias.ts
+++ b/apps/backend/src/types/beneficiarias.ts
@@ -10,6 +10,39 @@ export interface BeneficiariaFamiliar {
   observacoes?: string | null;
 }
 
+export interface BeneficiariaInfoSocioeconomica {
+  renda_familiar?: number | null;
+  quantidade_moradores?: number | null;
+  tipo_moradia?: string | null;
+  escolaridade?: string | null;
+  profissao?: string | null;
+  situacao_trabalho?: string | null;
+  beneficios_sociais?: string[] | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface BeneficiariaDependente {
+  id: number;
+  nome_completo: string;
+  data_nascimento: Date;
+  parentesco: string;
+  cpf?: string | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface BeneficiariaHistoricoAtendimento {
+  id: number;
+  data: Date;
+  tipo: string;
+  descricao: string;
+  encaminhamentos?: string | null;
+  profissional_id?: number | null;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
 export interface Beneficiaria {
   id: number;
   codigo: string;
@@ -42,6 +75,9 @@ export interface Beneficiaria {
   medida_protetiva?: boolean | null;
   acompanhamento_juridico?: boolean | null;
   acompanhamento_psicologico?: boolean | null;
+  foto_filename?: string | null;
+  foto_url?: string | null;
+  arquivada_em?: Date | null;
   created_at?: Date;
   updated_at?: Date;
   deleted_at?: Date | null;
@@ -50,6 +86,9 @@ export interface Beneficiaria {
 export interface BeneficiariaDetalhada extends Beneficiaria {
   familiares: BeneficiariaFamiliar[];
   vulnerabilidades: string[];
+  info_socioeconomica?: BeneficiariaInfoSocioeconomica | null;
+  dependentes?: BeneficiariaDependente[];
+  historico_atendimentos?: BeneficiariaHistoricoAtendimento[];
 }
 
 export interface BeneficiariaFiltros {

--- a/apps/backend/src/validators/beneficiaria.validator.ts
+++ b/apps/backend/src/validators/beneficiaria.validator.ts
@@ -10,6 +10,11 @@ const optionalDate = z.string()
   .nullable()
   .refine(value => !value || value < new Date(), 'Data informada não pode ser futura');
 
+const requiredDate = z.string()
+  .regex(dateRegex, 'Data deve estar no formato YYYY-MM-DD')
+  .transform(value => new Date(value))
+  .refine(value => value < new Date(), 'Data informada não pode ser futura');
+
 const familiarSchema = z.object({
   nome: z.string().min(2, 'Nome do familiar é obrigatório').max(150),
   parentesco: z.string().max(80, 'Parentesco deve ter no máximo 80 caracteres').optional(),
@@ -82,3 +87,46 @@ export const validateBeneficiaria = async (
   const schema = partial ? beneficiariaSchema.partial() : beneficiariaSchema;
   return schema.parseAsync(data);
 };
+
+export const infoSocioeconomicaSchema = z.object({
+  renda_familiar: z.number().min(0).optional().nullable(),
+  quantidade_moradores: z.number().int().min(0).optional().nullable(),
+  tipo_moradia: z.string().max(120).optional().nullable(),
+  escolaridade: z.string().max(120).optional().nullable(),
+  profissao: z.string().max(120).optional().nullable(),
+  situacao_trabalho: z.string().max(120).optional().nullable(),
+  beneficios_sociais: z.array(z.string().max(120)).optional().nullable()
+});
+
+export const dependenteSchema = z.object({
+  nome_completo: z
+    .string()
+    .min(3, 'Nome deve ter no mínimo 3 caracteres')
+    .max(150, 'Nome deve ter no máximo 150 caracteres'),
+  data_nascimento: requiredDate,
+  parentesco: z
+    .string()
+    .min(2, 'Parentesco deve ter no mínimo 2 caracteres')
+    .max(120, 'Parentesco deve ter no máximo 120 caracteres'),
+  cpf: z
+    .string()
+    .length(11, 'CPF deve ter 11 dígitos')
+    .refine(cpf => isCPF(cpf), 'CPF inválido')
+    .optional()
+    .nullable()
+});
+
+export const atendimentoSchema = z.object({
+  tipo: z
+    .string()
+    .min(3, 'Tipo do atendimento deve ter ao menos 3 caracteres')
+    .max(120, 'Tipo do atendimento deve ter no máximo 120 caracteres'),
+  data: z.coerce
+    .date()
+    .refine((value) => !Number.isNaN(value.getTime()), 'Data do atendimento é obrigatória'),
+  descricao: z
+    .string()
+    .min(5, 'Descrição deve ter ao menos 5 caracteres'),
+  encaminhamentos: z.string().optional().nullable(),
+  profissional_id: z.number().int().positive().optional().nullable()
+});

--- a/apps/frontend/src/types/shared/index.ts
+++ b/apps/frontend/src/types/shared/index.ts
@@ -69,6 +69,9 @@ export interface Beneficiaria {
     observacoes_socioeconomicas?: string | null;
     status: 'ativa' | 'inativa' | 'pendente' | 'desistente';
     observacoes?: string | null;
+    foto_filename?: string | null;
+    foto_url?: string | null;
+    arquivada_em?: string | null;
     created_at?: string;
     updated_at?: string;
     familiares?: Array<{
@@ -89,6 +92,8 @@ export interface Beneficiaria {
         profissao?: string | null;
         situacao_trabalho?: string | null;
         beneficios_sociais?: string[] | null;
+        created_at?: string;
+        updated_at?: string;
     } | null;
     dependentes?: Array<{
         id?: number;
@@ -96,13 +101,18 @@ export interface Beneficiaria {
         data_nascimento: string;
         parentesco: string;
         cpf?: string;
+        created_at?: string;
+        updated_at?: string;
     }>;
     historico_atendimentos?: Array<{
         id: number;
         data: string;
         tipo: string;
         descricao: string;
+        encaminhamentos?: string | null;
         profissional_id?: number;
+        created_at?: string;
+        updated_at?: string;
     }>;
 }
 

--- a/packages/types/src/beneficiarias.ts
+++ b/packages/types/src/beneficiarias.ts
@@ -12,6 +12,39 @@ export interface BeneficiariaFamiliar {
   observacoes?: string | null;
 }
 
+export interface BeneficiariaInfoSocioeconomica {
+  renda_familiar?: number | null;
+  quantidade_moradores?: number | null;
+  tipo_moradia?: string | null;
+  escolaridade?: string | null;
+  profissao?: string | null;
+  situacao_trabalho?: string | null;
+  beneficios_sociais?: string[] | null;
+  created_at?: TemporalValue;
+  updated_at?: TemporalValue;
+}
+
+export interface BeneficiariaDependente {
+  id: number;
+  nome_completo: string;
+  data_nascimento: TemporalValue;
+  parentesco: string;
+  cpf?: string | null;
+  created_at?: TemporalValue;
+  updated_at?: TemporalValue;
+}
+
+export interface BeneficiariaHistoricoAtendimento {
+  id: number;
+  data: TemporalValue;
+  tipo: string;
+  descricao: string;
+  encaminhamentos?: string | null;
+  profissional_id?: number | null;
+  created_at?: TemporalValue;
+  updated_at?: TemporalValue;
+}
+
 export interface Beneficiaria {
   id: number;
   codigo: string;
@@ -44,6 +77,9 @@ export interface Beneficiaria {
   medida_protetiva?: boolean | null;
   acompanhamento_juridico?: boolean | null;
   acompanhamento_psicologico?: boolean | null;
+  foto_filename?: string | null;
+  foto_url?: string | null;
+  arquivada_em?: TemporalValue | null;
   created_at?: TemporalValue;
   updated_at?: TemporalValue;
   deleted_at?: TemporalValue | null;
@@ -52,6 +88,9 @@ export interface Beneficiaria {
 export interface BeneficiariaDetalhada extends Beneficiaria {
   familiares: BeneficiariaFamiliar[];
   vulnerabilidades: string[];
+  info_socioeconomica?: BeneficiariaInfoSocioeconomica | null;
+  dependentes?: BeneficiariaDependente[];
+  historico_atendimentos?: BeneficiariaHistoricoAtendimento[];
 }
 
 export interface BeneficiariaFiltros {


### PR DESCRIPTION
## Summary
- add dedicated endpoints for archiving beneficiaries, updating socio-economic data, managing dependents and attendances, and handling profile photo uploads
- extend the beneficiaries service and repository with new persistence logic, including info socioeconômica, dependents, atendimento history, and photo storage metadata
- introduce a database migration for the new relational tables/columns and expand integration coverage to exercise all new routes

## Testing
- RUN_INTEGRATION=1 node --require ./tests/mocks/registerAnsi.js ../../node_modules/jest/bin/jest.js -c jest.integration.config.js src/__tests__/integration/beneficiarias.integration.test.ts *(fails: existing TypeScript errors in planoAcaoController)*

------
https://chatgpt.com/codex/tasks/task_e_68da75cd4dc483248b9eb0576221f5be