### PR TITLE
Fix backend build type errors and update readiness report

### DIFF
--- a/RELATORIO_PRONTIDAO_PRODUCAO.md
+++ b/RELATORIO_PRONTIDAO_PRODUCAO.md
@@ -1,51 +1,51 @@
 # 🚀 Relatório de Prontidão para Produção
 
-_Gerado em 2025-09-29T01:04:11.198Z_
+_Gerado em 2025-09-29T13:12:37.879Z_
 
 ## ✅ Resumo Executivo
-- **Status Geral:** ⚠️ ATENÇÃO - AJUSTES NECESSÁRIOS
+- **Status Geral:** ✅ PRONTO PARA PRODUÇÃO
 - **Branch Analisada:** `work`
-- **Commit:** `5bf8c52`
+- **Commit:** `194600b`
 - **Workspace Limpo:** Não
 - **Node.js / npm:** v20.19.4 / 11.4.2
 
 ## 🧪 Checks Automáticos
 | Check | Status | Duração | Última saída |
 | ----- | ------ | ------- | ------------ |
-| Build Frontend | ✅ Sucesso | 16.34 s | ✓ built in 14.49s |
-| Build Backend | ❌ Falha | 6.31 s | npm error command sh -c tsc -p tsconfig.build.json |
-| Lint Backend | ✅ Sucesso | 4.18 s | 0 errors and 94 warnings potentially fixable with the `--fix` option. |
-| Teste Backend (security.setup) | ✅ Sucesso | 4.03 s | > node --require ./tests/mocks/registerAnsi.js ../../node_modules/jest/bin/jest.js apps/backend/src/__tests__/security.setup.test.ts |
-| Teste Frontend (ErrorBoundary) | ✅ Sucesso | 2.88 s | Duration  1.82s (transform 134ms, setup 65ms, collect 432ms, tests 54ms, environment 562ms, prepare 92ms) |
+| Build Frontend | ✅ Sucesso | 15.93 s | ✓ built in 14.48s |
+| Build Backend | ✅ Sucesso | 6.24 s | > tsc -p tsconfig.build.json |
+| Lint Backend | ✅ Sucesso | 4.16 s | 0 errors and 93 warnings potentially fixable with the `--fix` option. |
+| Teste Backend (security.setup) | ✅ Sucesso | 4.99 s | > node --require ./tests/mocks/registerAnsi.js ../../node_modules/jest/bin/jest.js apps/backend/src/__tests__/security.setup.test.ts |
+| Teste Frontend (ErrorBoundary) | ✅ Sucesso | 3.24 s | Duration  2.13s (transform 159ms, setup 75ms, collect 509ms, tests 46ms, environment 623ms, prepare 147ms) |
 
 ## 📦 Métricas de Código
 ### Backend
-- Rotas (arquivos .ts): **40**
+- Rotas (arquivos .ts): **41**
 - Controladores: **8**
-- Serviços: **29**
-- Arquivos de teste (.test/.spec.ts): **42**
+- Serviços: **30**
+- Arquivos de teste (.test/.spec.ts): **44**
 
 ### Frontend
 - Páginas (.tsx): **46**
 - Componentes (.tsx): **79**
 - Hooks (.ts): **31**
-- Arquivos de teste: **59**
+- Arquivos de teste: **60**
 
 ### Base do Repositório
-- Total de arquivos TypeScript/TSX: **487**
+- Total de arquivos TypeScript/TSX: **490**
 - TODOs/FIXMEs identificados: **0**
 
 ## 🗄️ Migrações e Seeds
-- Migrações disponíveis: **53**
-  - 044_alter_termos_consentimento_add_metadata.sql
+- Migrações disponíveis: **54**
   - 045_criar_push_subscriptions.sql
   - 046_criar_job_queue.sql
   - 047_criar_login_attempts_user_blocks.sql
   - 048_criar_user_refresh_tokens.sql
+  - 049_extend_beneficiarias_relations.sql
 - Seeds disponíveis: **1**
   - 001_seed_beneficiarias.sql
 
 ## 📌 Observações
-- Há falhas nas checagens; revisar os logs acima antes do deploy.
+- Todas as checagens automatizadas foram executadas com sucesso.
 - Relatório gerado automaticamente pelo script `scripts/generate-readiness-report.js`.
 

--- a/apps/backend/src/controllers/planoAcaoController.ts
+++ b/apps/backend/src/controllers/planoAcaoController.ts
@@ -173,7 +173,7 @@ export const planoAcaoController = {
       }
     } catch (error) {
       if (error instanceof ZodError) {
-        return res.status(400).json({ error: 'Dados inválidos', detalhes: error.errors });
+        return res.status(400).json({ error: 'Dados inválidos', detalhes: error.issues });
       }
       logger.error('Erro ao criar plano de ação:', error);
       return res.status(500).json({ error: 'Erro interno do servidor' });
@@ -253,7 +253,7 @@ export const planoAcaoController = {
       }
     } catch (error) {
       if (error instanceof ZodError) {
-        return res.status(400).json({ error: 'Dados inválidos', detalhes: error.errors });
+        return res.status(400).json({ error: 'Dados inválidos', detalhes: error.issues });
       }
       logger.error('Erro ao atualizar plano de ação:', error);
       return res.status(500).json({ error: 'Erro interno do servidor' });

--- a/apps/backend/src/middleware/__mocks__/auth.ts
+++ b/apps/backend/src/middleware/__mocks__/auth.ts
@@ -10,9 +10,9 @@ type AuthRequest = Request & {
 
 type AuthMiddleware = (req: AuthRequest, res: Response, next: () => void) => void;
 
-export const authenticateToken = jest.fn<AuthMiddleware>().mockImplementation(
-  (req: AuthRequest, res: Response, next: () => void) => {
-    req.user = { id: 123, role: 'admin' };
-    next();
-  }
-);
+const authenticateTokenImpl: AuthMiddleware = (req, _res, next) => {
+  req.user = { id: 123, role: 'admin' };
+  next();
+};
+
+export const authenticateToken = jest.fn(authenticateTokenImpl) as jest.MockedFunction<AuthMiddleware>;

--- a/apps/backend/src/middleware/__mocks__/upload.ts
+++ b/apps/backend/src/middleware/__mocks__/upload.ts
@@ -3,8 +3,8 @@ import { jest } from '@jest/globals';
 
 type UploadMiddleware = (req: Request, res: Response, next: () => void) => void;
 
-export const uploadMiddleware = jest.fn<UploadMiddleware>().mockImplementation(
-  (req: Request, res: Response, next: () => void) => {
-    next();
-  }
-);
+const uploadMiddlewareImpl: UploadMiddleware = (_req, _res, next) => {
+  next();
+};
+
+export const uploadMiddleware = jest.fn(uploadMiddlewareImpl) as jest.MockedFunction<UploadMiddleware>;

--- a/apps/backend/src/types/express.ts
+++ b/apps/backend/src/types/express.ts
@@ -1,11 +1,11 @@
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
+import type { ParamsDictionary } from 'express-serve-static-core';
+import type { ParsedQs } from 'qs';
 
-export interface TypedRequest<T = any, P = any> extends Request {
-  body: T;
-  params: P;
-}
+export type TypedRequest<
+  T = any,
+  P extends ParamsDictionary = ParamsDictionary,
+  Q extends ParsedQs = ParsedQs
+> = Request<P, any, T, Q>;
 
-export interface TypedResponse<T = any> extends Response {
-  json: (body: T) => TypedResponse<T>;
-  status: (code: number) => TypedResponse<T>;
-}
+export type TypedResponse<T = any> = Response<T>;


### PR DESCRIPTION
## Summary
- adjust the Plano de Ação controller to return Zod issue details when validation fails
- refine mocked middleware types and internal CORS typing so the backend build no longer hits TypeScript errors
- refresh the readiness report after the successful build

## Testing
- npm --prefix apps/backend run build
- node scripts/generate-readiness-report.js

------
https://chatgpt.com/codex/tasks/task_e_68da84b3d4cc8324887d3b05b05eb90a