### PR TITLE
Add response typing for listarOficinas cache usage

### DIFF
--- a/apps/backend/src/services/oficina.service.ts
+++ b/apps/backend/src/services/oficina.service.ts
@@ -31,6 +31,16 @@ type OficinaColumnMap = {
   data_atualizacao: string | null;
 };
 
+export type ListarOficinasResponse = {
+  data: Oficina[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
 export class OficinaService {
   private pool: Pool;
   private redis: RedisClient;
@@ -146,7 +156,7 @@ export class OficinaService {
     }
   }
 
-  async listarOficinas(filters: OficinaFilters) {
+  async listarOficinas(filters: OficinaFilters): Promise<ListarOficinasResponse> {
     try {
       const { page, limit, projeto_id, status, data_inicio, data_fim, instrutor, local, search } = filters;
       const offset = (page - 1) * limit;
@@ -154,7 +164,7 @@ export class OficinaService {
       // Tentar buscar do cache se não houver filtros complexos
       if (!search && !data_inicio && !data_fim && page === 1) {
         const cacheKey = `list:${projeto_id || 'all'}:${status || 'all'}:${limit}`;
-        const cachedData = await this.getCacheKey(cacheKey);
+        const cachedData = await this.getCacheKey<ListarOficinasResponse>(cacheKey);
         if (cachedData) {
           return cachedData;
         }
@@ -261,7 +271,7 @@ export class OficinaService {
       const oficinas = formatArrayDates(result.rows, ['data_inicio', 'data_fim', 'data_criacao', 'data_atualizacao']);
       const total = result.rows.length > 0 ? parseInt(result.rows[0].total_count) : 0;
 
-      const response = {
+      const response: ListarOficinasResponse = {
         data: oficinas,
         pagination: {
           page: parseInt(String(page)),


### PR DESCRIPTION
## Summary
- define a ListarOficinasResponse type for oficina listings
- apply the response type to listarOficinas and associated cache calls to preserve type safety

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da8c3e92a88324ad6d1a088fd6a565