### PR TITLE
Use proper jest spy type in oficina service tests

### DIFF
--- a/apps/backend/src/services/__tests__/oficina.service.test.ts
+++ b/apps/backend/src/services/__tests__/oficina.service.test.ts
@@ -13,7 +13,7 @@ describe('OficinaService', () => {
   let oficinaService: OficinaService;
   let mockPool: MockPool;
   let mockRedis: MockRedis;
-  let cacheGetSpy: jest.SpyInstance;
+  let cacheGetSpy: jest.SpiedFunction<typeof cacheService.get>;
 
   const mockOficina: Oficina = {
     id: 1,


### PR DESCRIPTION
## Summary
- replace the deprecated jest.SpyInstance annotation with jest.SpiedFunction for cacheService.get
- ensure the cache spy declaration remains compatible with existing tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8c3f85a08324930dfe55aa87eb15