### PR TITLE
Add gestor middleware mock to auth security tests

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -6,6 +6,7 @@ const originalEnableLoginRateLimit = process.env.ENABLE_LOGIN_RATE_LIMIT;
 jest.mock('../../middleware/auth', () => ({
   authenticateToken: jest.fn((_req: any, _res: any, next: any) => next()),
   requireProfissional: jest.fn(),
+  requireGestor: jest.fn((_req: any, _res: any, next: any) => next()),
   authorize: () => (_req: any, _res: any, next: any) => next()
 }));
 


### PR DESCRIPTION
## Summary
- extend the auth middleware mock in auth.security.routes.test.ts to include a no-op requireGestor handler so the route mounts cleanly during tests

## Testing
- npm test -- src/routes/__tests__/auth.security.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da8c42c5fc8324a7e3d23c0e29440a