### PR TITLE
Add requireGestor mock to auth security route tests

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -5,6 +5,7 @@ const originalEnableLoginRateLimit = process.env.ENABLE_LOGIN_RATE_LIMIT;
 
 jest.mock('../../middleware/auth', () => ({
   authenticateToken: jest.fn((_req: any, _res: any, next: any) => next()),
+  requireGestor: jest.fn((_req: any, _res: any, next: any) => next()),
   requireProfissional: jest.fn(),
   authorize: () => (_req: any, _res: any, next: any) => next()
 }));


### PR DESCRIPTION
## Summary
- mock the requireGestor middleware in the auth security route tests so route registration succeeds during test setup

## Testing
- npm test --workspace=apps/backend *(fails: existing TypeScript and integration test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68da8c4a7a00832485bf5e68913d2fdd