### PR TITLE
test: reject unsigned csrf cookie

### DIFF
--- a/apps/backend/src/__tests__/csrf.middleware.test.ts
+++ b/apps/backend/src/__tests__/csrf.middleware.test.ts
@@ -41,7 +41,7 @@ describe('csrfMiddleware integration', () => {
     expect(response.body).toEqual({ error: 'CSRF token inválido' });
   });
 
-  it('should allow requests with an unsigned legacy CSRF token', async () => {
+  it('should reject unsigned legacy CSRF tokens and refresh the cookie', async () => {
     const token = 'legacy-token';
     const app = setupTestApp();
 
@@ -51,8 +51,12 @@ describe('csrfMiddleware integration', () => {
       .set('X-CSRF-Token', token)
       .send({ value: 'test' });
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({ ok: true });
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ error: 'CSRF token inválido' });
+
+    const cookies = response.headers['set-cookie'] as string[] | undefined;
+    expect(cookies?.some((cookie) => cookie.startsWith('csrf_token='))).toBe(true);
+    expect(cookies?.some((cookie) => cookie.includes('csrf_token=s%3A'))).toBe(true);
   });
 
   it('should expose a signed CSRF token via GET /api/csrf-token', async () => {


### PR DESCRIPTION
## Summary
- update CSRF middleware integration test to treat unsigned legacy cookies as invalid
- assert that a new signed csrf_token cookie is issued when an unsigned token is rejected

## Testing
- npm test --workspace=apps/backend *(fails: pre-existing TypeScript errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68da8c4bb9a48324b8cd2ea2d3429c8b