### PR TITLE
Mock requireGestor middleware in auth security tests

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -6,6 +6,7 @@ const originalEnableLoginRateLimit = process.env.ENABLE_LOGIN_RATE_LIMIT;
 jest.mock('../../middleware/auth', () => ({
   authenticateToken: jest.fn((_req: any, _res: any, next: any) => next()),
   requireProfissional: jest.fn(),
+  requireGestor: jest.fn((_req: any, _res: any, next: any) => next()),
   authorize: () => (_req: any, _res: any, next: any) => next()
 }));
 


### PR DESCRIPTION
## Summary
- add a requireGestor noop mock to the auth middleware used in the auth security route tests so the router mounts cleanly when the guard is required

## Testing
- npm run test:backend -- --runTestsByPath apps/backend/src/routes/__tests__/auth.security.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da8d020b348324bc2fca8bd81a0559