### PR TITLE
Adjust participacao controller tests to use next mocks

### DIFF
--- a/apps/backend/src/controllers/__tests__/participacao.controller.test.ts
+++ b/apps/backend/src/controllers/__tests__/participacao.controller.test.ts
@@ -6,15 +6,46 @@ import {
   registrarPresenca,
   emitirCertificado
 } from '../participacao.controller';
-import { ParticipacaoService } from '../../services/participacao.service';
+import { AppError, ValidationError } from '../../utils';
 
-// Mock do ParticipacaoService
-jest.mock('../../services/participacao.service');
+type ParticipacaoServiceMocks = {
+  listarParticipacoes: jest.Mock;
+  criarParticipacao: jest.Mock;
+  atualizarParticipacao: jest.Mock;
+  excluirParticipacao: jest.Mock;
+  registrarPresenca: jest.Mock;
+  emitirCertificado: jest.Mock;
+};
+
+jest.mock('../../services/participacao.service', () => {
+  const serviceMocks: ParticipacaoServiceMocks = {
+    listarParticipacoes: jest.fn(),
+    criarParticipacao: jest.fn(),
+    atualizarParticipacao: jest.fn(),
+    excluirParticipacao: jest.fn(),
+    registrarPresenca: jest.fn(),
+    emitirCertificado: jest.fn()
+  };
+
+  return {
+    ParticipacaoService: jest.fn().mockImplementation(() => serviceMocks),
+    __mocks: serviceMocks
+  };
+});
+
+const {
+  listarParticipacoes: mockListarParticipacoes,
+  criarParticipacao: mockCriarParticipacao,
+  atualizarParticipacao: mockAtualizarParticipacao,
+  excluirParticipacao: mockExcluirParticipacao,
+  registrarPresenca: mockRegistrarPresenca,
+  emitirCertificado: mockEmitirCertificado
+} = (jest.requireMock('../../services/participacao.service') as { __mocks: ParticipacaoServiceMocks }).__mocks;
 
 describe('ParticipacaoController', () => {
   let mockReq: any;
   let mockRes: any;
-  let mockParticipacaoService: any;
+  let next: jest.Mock;
 
   beforeEach(() => {
     mockReq = {
@@ -27,17 +58,13 @@ describe('ParticipacaoController', () => {
       status: jest.fn().mockReturnThis(),
       send: jest.fn()
     };
-    mockParticipacaoService = ParticipacaoService as jest.MockedClass<typeof ParticipacaoService>;
-    mockParticipacaoService.prototype.listarParticipacoes = jest.fn();
-    mockParticipacaoService.prototype.criarParticipacao = jest.fn();
-    mockParticipacaoService.prototype.atualizarParticipacao = jest.fn();
-    mockParticipacaoService.prototype.excluirParticipacao = jest.fn();
-    mockParticipacaoService.prototype.registrarPresenca = jest.fn();
-    mockParticipacaoService.prototype.emitirCertificado = jest.fn();
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
+    mockListarParticipacoes.mockReset();
+    mockCriarParticipacao.mockReset();
+    mockAtualizarParticipacao.mockReset();
+    mockExcluirParticipacao.mockReset();
+    mockRegistrarPresenca.mockReset();
+    mockEmitirCertificado.mockReset();
+    next = jest.fn();
   });
 
   describe('listarParticipacoes', () => {
@@ -46,31 +73,33 @@ describe('ParticipacaoController', () => {
         data: [{ id: 1 }],
         pagination: { total: 1 }
       };
-      mockParticipacaoService.prototype.listarParticipacoes.mockResolvedValue(mockResult);
+      mockListarParticipacoes.mockResolvedValue(mockResult);
 
       mockReq.query = {
         page: '1',
         limit: '10'
       };
 
-      await listarParticipacoes(mockReq, mockRes);
+      await listarParticipacoes(mockReq, mockRes, next);
 
       expect(mockRes.json).toHaveBeenCalledWith(mockResult);
-      expect(mockParticipacaoService.prototype.listarParticipacoes).toHaveBeenCalledWith({
+      expect(mockListarParticipacoes).toHaveBeenCalledWith({
         page: 1,
         limit: 10
       });
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve tratar erro ao listar participações', async () => {
-      mockParticipacaoService.prototype.listarParticipacoes.mockRejectedValue(new Error());
+      mockListarParticipacoes.mockRejectedValue(new Error());
 
-      await listarParticipacoes(mockReq, mockRes);
+      await listarParticipacoes(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(500);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Erro interno ao buscar participações' 
-      });
+      expect(next).toHaveBeenCalledTimes(1);
+      const error = next.mock.calls[0][0] as AppError;
+      expect(error).toBeInstanceOf(AppError);
+      expect(error.message).toBe('Erro interno ao buscar participações');
+      expect(error.statusCode).toBe(500);
     });
   });
 
@@ -81,30 +110,27 @@ describe('ParticipacaoController', () => {
         beneficiaria_id: 1,
         projeto_id: 1
       };
-      mockParticipacaoService.prototype.criarParticipacao.mockResolvedValue(mockParticipacao);
+      mockCriarParticipacao.mockResolvedValue(mockParticipacao);
 
       mockReq.body = {
         beneficiaria_id: 1,
         projeto_id: 1
       };
 
-      await criarParticipacao(mockReq, mockRes);
+      await criarParticipacao(mockReq, mockRes, next);
 
       expect(mockRes.status).toHaveBeenCalledWith(201);
       expect(mockRes.json).toHaveBeenCalledWith(mockParticipacao);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve tratar erro de beneficiária não encontrada', async () => {
-      mockParticipacaoService.prototype.criarParticipacao.mockRejectedValue(
-        new Error('Beneficiária não encontrada')
-      );
+      const error = new Error('Beneficiária não encontrada');
+      mockCriarParticipacao.mockRejectedValue(error);
 
-      await criarParticipacao(mockReq, mockRes);
+      await criarParticipacao(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(404);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Beneficiária não encontrada' 
-      });
+      expect(next).toHaveBeenCalledWith(error);
     });
   });
 
@@ -114,57 +140,51 @@ describe('ParticipacaoController', () => {
         id: 1,
         status: 'em_andamento'
       };
-      mockParticipacaoService.prototype.atualizarParticipacao.mockResolvedValue(mockParticipacao);
+      mockAtualizarParticipacao.mockResolvedValue(mockParticipacao);
 
       mockReq.params = { id: '1' };
       mockReq.body = { status: 'em_andamento' };
 
-      await atualizarParticipacao(mockReq, mockRes);
+      await atualizarParticipacao(mockReq, mockRes, next);
 
       expect(mockRes.json).toHaveBeenCalledWith(mockParticipacao);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve tratar erro de participação não encontrada', async () => {
-      mockParticipacaoService.prototype.atualizarParticipacao.mockRejectedValue(
-        new Error('Participação não encontrada')
-      );
+      const error = new Error('Participação não encontrada');
+      mockAtualizarParticipacao.mockRejectedValue(error);
 
       mockReq.params = { id: '999' };
 
-      await atualizarParticipacao(mockReq, mockRes);
+      await atualizarParticipacao(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(404);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Participação não encontrada' 
-      });
+      expect(next).toHaveBeenCalledWith(error);
     });
   });
 
   describe('excluirParticipacao', () => {
     it('deve excluir participação com sucesso', async () => {
-      mockParticipacaoService.prototype.excluirParticipacao.mockResolvedValue(undefined);
+      mockExcluirParticipacao.mockResolvedValue(undefined);
 
       mockReq.params = { id: '1' };
 
-      await excluirParticipacao(mockReq, mockRes);
+      await excluirParticipacao(mockReq, mockRes, next);
 
       expect(mockRes.status).toHaveBeenCalledWith(204);
       expect(mockRes.send).toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve tratar erro de participação não encontrada', async () => {
-      mockParticipacaoService.prototype.excluirParticipacao.mockRejectedValue(
-        new Error('Participação não encontrada')
-      );
+      const error = new Error('Participação não encontrada');
+      mockExcluirParticipacao.mockRejectedValue(error);
 
       mockReq.params = { id: '999' };
 
-      await excluirParticipacao(mockReq, mockRes);
+      await excluirParticipacao(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(404);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Participação não encontrada' 
-      });
+      expect(next).toHaveBeenCalledWith(error);
     });
   });
 
@@ -174,42 +194,39 @@ describe('ParticipacaoController', () => {
         id: 1,
         presenca_percentual: 80
       };
-      mockParticipacaoService.prototype.registrarPresenca.mockResolvedValue(mockParticipacao);
+      mockRegistrarPresenca.mockResolvedValue(mockParticipacao);
 
       mockReq.params = { id: '1' };
       mockReq.body = { presenca: 80 };
 
-      await registrarPresenca(mockReq, mockRes);
+      await registrarPresenca(mockReq, mockRes, next);
 
       expect(mockRes.json).toHaveBeenCalledWith(mockParticipacao);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve validar presença obrigatória', async () => {
       mockReq.params = { id: '1' };
       mockReq.body = {};
 
-      await registrarPresenca(mockReq, mockRes);
+      await registrarPresenca(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Percentual de presença é obrigatório' 
-      });
+      expect(next).toHaveBeenCalledTimes(1);
+      const error = next.mock.calls[0][0] as ValidationError;
+      expect(error).toBeInstanceOf(ValidationError);
+      expect(error.message).toBe('Percentual de presença é obrigatório');
     });
 
     it('deve validar presença entre 0 e 100', async () => {
-      mockParticipacaoService.prototype.registrarPresenca.mockRejectedValue(
-        new Error('Percentual de presença deve estar entre 0 e 100')
-      );
+      const error = new Error('Percentual de presença deve estar entre 0 e 100');
+      mockRegistrarPresenca.mockRejectedValue(error);
 
       mockReq.params = { id: '1' };
       mockReq.body = { presenca: 101 };
 
-      await registrarPresenca(mockReq, mockRes);
+      await registrarPresenca(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Percentual de presença deve estar entre 0 e 100' 
-      });
+      expect(next).toHaveBeenCalledWith(error);
     });
   });
 
@@ -220,28 +237,25 @@ describe('ParticipacaoController', () => {
         certificado_emitido: true,
         status: 'concluida'
       };
-      mockParticipacaoService.prototype.emitirCertificado.mockResolvedValue(mockParticipacao);
+      mockEmitirCertificado.mockResolvedValue(mockParticipacao);
 
       mockReq.params = { id: '1' };
 
-      await emitirCertificado(mockReq, mockRes);
+      await emitirCertificado(mockReq, mockRes, next);
 
       expect(mockRes.json).toHaveBeenCalledWith(mockParticipacao);
+      expect(next).not.toHaveBeenCalled();
     });
 
     it('deve validar presença mínima', async () => {
-      mockParticipacaoService.prototype.emitirCertificado.mockRejectedValue(
-        new Error('Presença mínima de 75% é necessária para emitir certificado')
-      );
+      const error = new Error('Presença mínima de 75% é necessária para emitir certificado');
+      mockEmitirCertificado.mockRejectedValue(error);
 
       mockReq.params = { id: '1' };
 
-      await emitirCertificado(mockReq, mockRes);
+      await emitirCertificado(mockReq, mockRes, next);
 
-      expect(mockRes.status).toHaveBeenCalledWith(400);
-      expect(mockRes.json).toHaveBeenCalledWith({ 
-        error: 'Presença mínima de 75% é necessária para emitir certificado' 
-      });
+      expect(next).toHaveBeenCalledWith(error);
     });
   });
 });


### PR DESCRIPTION
## Summary
- update ParticipacaoController tests to pass a mocked next function to each handler invocation
- manually mock ParticipacaoService methods so the tests can control resolved and rejected values
- assert that error scenarios call next with the expected AppError or other thrown errors

## Testing
- npm test --workspace=apps/backend -- participacao.controller.test.ts
- npm test --workspace=apps/backend *(fails: existing failures in auth.service, csrf middleware, oficina.service, auth.security suites)*

------
https://chatgpt.com/codex/tasks/task_e_68da8c48fe848324b4a4728b5ad93c23