### PR TITLE
Ensure auth middleware mock exports requireGestor

### DIFF
--- a/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
+++ b/apps/backend/src/routes/__tests__/auth.security.routes.test.ts
@@ -5,6 +5,7 @@ const originalEnableLoginRateLimit = process.env.ENABLE_LOGIN_RATE_LIMIT;
 
 jest.mock('../../middleware/auth', () => ({
   authenticateToken: jest.fn((_req: any, _res: any, next: any) => next()),
+  requireGestor: jest.fn((_req: any, _res: any, next: any) => next()),
   requireProfissional: jest.fn(),
   authorize: () => (_req: any, _res: any, next: any) => next()
 }));


### PR DESCRIPTION
## Summary
- extend the auth middleware mock in the route security tests to include the requireGestor handler with a passthrough signature
- keep existing mock handlers intact so the suite continues focusing on login limiting behavior

## Testing
- npm test -- auth.security.routes.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68da8cf370648324a700740f96baf225