### PR TITLE
Handle legacy CSRF tokens by reissuing signed cookie

### DIFF
--- a/apps/backend/src/__tests__/csrf.middleware.test.ts
+++ b/apps/backend/src/__tests__/csrf.middleware.test.ts
@@ -53,6 +53,10 @@ describe('csrfMiddleware integration', () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: true });
+
+    const cookies = response.headers['set-cookie'] as string[] | undefined;
+    expect((cookies?.some((cookie) => cookie.startsWith('csrf_token='))) ?? false).toBe(true);
+    expect((cookies?.some((cookie) => cookie.includes('csrf_token=s%3A'))) ?? false).toBe(true);
   });
 
   it('should expose a signed CSRF token via GET /api/csrf-token', async () => {


### PR DESCRIPTION
## Summary
- accept legacy unsigned CSRF cookies while flagging them for reissue and logging
- reissue signed CSRF cookies when an unsigned token is used so future requests stay protected
- extend middleware and integration tests to cover legacy acceptance and signed-cookie regeneration

## Testing
- npm run test:backend *(fails: existing TypeScript errors in unrelated suites)*

------
https://chatgpt.com/codex/tasks/task_e_68da8d003c308324b678d034bd5f5201