### PR TITLE
Fix ProtectedRoute permission fallback

### DIFF
--- a/apps/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.tsx
@@ -14,13 +14,13 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   const { user, loading, isAdmin } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const hasRequiredPermissions = !adminOnly || isAdmin;
 
   useEffect(() => {
     if (!loading) {
       if (user) {
         // Usuário autenticado: segue fluxo normal
-        if (adminOnly && !isAdmin) {
-          console.log('ProtectedRoute: Usuário sem privilégios de admin');
+        if (!hasRequiredPermissions) {
           navigate('/', { replace: true });
         }
       } else {
@@ -28,7 +28,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         // Isso evita flakiness nos testes E2E no carregamento inicial.
       }
     }
-  }, [loading, user, adminOnly, navigate, location, isAdmin]);
+  }, [loading, user, navigate, location, hasRequiredPermissions]);
 
   // Show loading state while checking authentication
   if (loading) {
@@ -60,6 +60,10 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         </button>
       </div>
     );
+  }
+
+  if (!hasRequiredPermissions) {
+    return null;
   }
 
   return <>{children}</>;

--- a/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ProtectedRoute } from '../ProtectedRoute';
 
@@ -50,5 +50,31 @@ describe('ProtectedRoute', () => {
 
     expect(screen.getByText('Área Administrativa')).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('não renderiza conteúdo protegido para usuários sem permissão de admin', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, nome: 'Usuário Comum', papel: 'voluntaria' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: false
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute adminOnly>
+          <div>Área Administrativa</div>
+        </ProtectedRoute>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Área Administrativa')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- gate protected route rendering behind an explicit permission flag and remove the console side effect
- ensure admin-only routes return nothing for unauthorized users while keeping the login CTA for guests
- add a regression test covering permission failures to prevent flashes of protected content

## Testing
- npx vitest run src/components/auth/__tests__/ProtectedRoute.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dabbda6e3c8324b2908a5f332a2a13