### PR TITLE
Refactor CI workflow for workspace installs and separate checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,59 +7,195 @@ on:
     branches: [ main ]
 
 jobs:
-  validate:
-    name: 🔎 Validate
+  install:
+    name: 📦 Install
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: 🏗 Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         cache: 'npm'
-        
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
     - name: 📦 Install Dependencies
-      run: |
-        npm ci
-        npm --prefix apps/frontend ci
-        npm --prefix apps/backend ci
-        
-    - name: 🔍 Lint
-      run: npm run lint
-      
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
+  lint-frontend:
+    name: 🔍 Lint Frontend
+    runs-on: ubuntu-latest
+    needs: install
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 🏗 Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
+    - name: 📦 Install Dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
+    - name: 🔍 Lint Frontend
+      run: npm run lint --workspace apps/frontend
+
+  lint-backend:
+    name: 🔍 Lint Backend
+    runs-on: ubuntu-latest
+    needs: install
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 🏗 Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
+    - name: 📦 Install Dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
+    - name: 🔍 Lint Backend
+      run: npm run lint --workspace apps/backend
+
+  type-check:
+    name: 🔄 Type Check
+    runs-on: ubuntu-latest
+    needs: install
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 🏗 Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
+    - name: 📦 Install Dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
     - name: 🔄 Type Check
       run: |
-        npm --prefix apps/frontend run type-check
-        npm --prefix apps/backend run type-check
-        
-    - name: 🧪 Test
-      run: npm test
-      
-  build:
-    name: 🏗 Build
-    needs: validate
+        npm run type-check --workspace apps/frontend
+        npm run type-check --workspace apps/backend
+
+  test:
+    name: 🧪 Test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
+    needs: install
+
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: 🏗 Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20.x'
         cache: 'npm'
-        
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
     - name: 📦 Install Dependencies
-      run: |
-        npm ci
-        npm --prefix apps/frontend ci
-        npm --prefix apps/backend ci
-        
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
+    - name: 🧪 Test
+      run: npm test
+
+  build:
+    name: 🏗 Build
+    needs:
+      - lint-frontend
+      - lint-backend
+      - type-check
+      - test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 🏗 Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: ♻️ Cache node modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          apps/frontend/node_modules
+          apps/backend/node_modules
+        key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'apps/frontend/package.json', 'apps/backend/package.json') }}
+
+    - name: 📦 Install Dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      run: npm ci --workspaces
+
     - name: 🏗 Build Frontend
-      run: npm --prefix apps/frontend run build
-      
+      run: npm run build --workspace apps/frontend
+
     - name: 🏗 Build Backend
-      run: npm --prefix apps/backend run build
+      run: npm run build --workspace apps/backend
+


### PR DESCRIPTION
## Summary
- switch the CI workflow to install dependencies with a single `npm ci --workspaces` using a shared cache
- split linting into dedicated frontend and backend jobs that call the workspace scripts directly
- add a dependent type-check job and update downstream jobs to reuse the cached install

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68dabb2f20a083248a9673e73fa02223