### PR TITLE
feat(frontend): guard protected routes with fallback

### DIFF
--- a/apps/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.tsx
@@ -7,6 +7,19 @@ interface ProtectedRouteProps {
   adminOnly?: boolean;
 }
 
+const Fallback: React.FC = () => (
+  <div
+    className="flex items-center justify-center min-h-screen bg-gradient-to-br from-primary/5 via-secondary/5 to-accent/5"
+    data-testid="protected-route-fallback"
+  >
+    <div className="text-center">
+      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+      <h3 className="text-lg font-semibold text-primary mb-2">Instituto Move Marias</h3>
+      <p className="text-muted-foreground">Carregando sistema...</p>
+    </div>
+  </div>
+);
+
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   children,
   adminOnly = false
@@ -30,17 +43,9 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     }
   }, [loading, user, adminOnly, navigate, location, isAdmin]);
 
-  // Show loading state while checking authentication
+  // Show fallback while checking authentication state
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-primary/5 via-secondary/5 to-accent/5">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-          <h3 className="text-lg font-semibold text-primary mb-2">Instituto Move Marias</h3>
-          <p className="text-muted-foreground">Carregando sistema...</p>
-        </div>
-      </div>
-    );
+    return <Fallback />;
   }
 
   // Render a minimal public landing with login CTA when not authenticated
@@ -60,6 +65,10 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         </button>
       </div>
     );
+  }
+
+  if (adminOnly && !isAdmin) {
+    return <Fallback />;
   }
 
   return <>{children}</>;

--- a/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -51,4 +51,50 @@ describe('ProtectedRoute', () => {
     expect(screen.getByText('Área Administrativa')).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it('renderiza fallback enquanto o estado de autenticação está carregando', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      profile: null,
+      loading: true,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: false,
+      isAdmin: false
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute>
+          <div>Conteúdo protegido</div>
+        </ProtectedRoute>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('protected-route-fallback')).toBeInTheDocument();
+    expect(screen.queryByText('Conteúdo protegido')).not.toBeInTheDocument();
+  });
+
+  it('não renderiza filhos quando usuário autenticado não é admin', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, nome: 'Usuário', papel: 'user' },
+      profile: null,
+      loading: false,
+      signIn: vi.fn(),
+      signOut: vi.fn(),
+      isAuthenticated: true,
+      isAdmin: false
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute adminOnly>
+          <div>Área Administrativa</div>
+        </ProtectedRoute>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('protected-route-fallback')).toBeInTheDocument();
+    expect(screen.queryByText('Área Administrativa')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add a reusable fallback screen to `ProtectedRoute` to cover loading and unauthorized admin states
- gate rendering of protected children until authentication and admin checks have passed
- extend `ProtectedRoute` unit tests to cover the new fallback behavior and prevent unauthorized flashes

## Testing
- npm run test:frontend -- src/components/auth/__tests__/ProtectedRoute.test.tsx src/routes/__tests__/restricted-routes.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dabb30c3f0832483030c53faf7fbe4