### PR TITLE
Restrict API response wrapping to internal base URL

### DIFF
--- a/apps/frontend/src/services/__tests__/apiService.test.ts
+++ b/apps/frontend/src/services/__tests__/apiService.test.ts
@@ -1,0 +1,58 @@
+import type { AxiosResponse } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import apiService from '@/services/apiService';
+import { API_URL } from '@/config';
+import type { ApiResponse } from '@/types/api';
+
+describe('apiService response interceptor', () => {
+  const getResponseInterceptor = () => {
+    const handlers = ((apiService as unknown as { api: { interceptors: { response: { handlers: any[] } } } }).api.interceptors
+      .response.handlers || []) as Array<{ fulfilled?: (response: AxiosResponse<ApiResponse>) => AxiosResponse<ApiResponse> }>;
+
+    const handler = handlers.find((item) => typeof item?.fulfilled === 'function')?.fulfilled;
+
+    if (!handler) {
+      throw new Error('Response interceptor not found');
+    }
+
+    return handler;
+  };
+
+  it('wraps responses from the internal API', () => {
+    const handler = getResponseInterceptor();
+
+    const response = {
+      data: { foo: 'bar' },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {
+        baseURL: API_URL,
+        url: '/internal/test',
+      },
+    } as AxiosResponse<ApiResponse>;
+
+    const result = handler(response);
+
+    expect(result.data).toEqual({ success: true, data: { foo: 'bar' } });
+  });
+
+  it('does not wrap external API responses', () => {
+    const handler = getResponseInterceptor();
+
+    const response = {
+      data: { foo: 'bar' },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {
+        url: 'https://third-party.example/api/data',
+      },
+    } as AxiosResponse<ApiResponse>;
+
+    const result = handler(response);
+
+    expect(result.data).toEqual({ foo: 'bar' });
+  });
+});


### PR DESCRIPTION
## Summary
- update the shared ApiService to use the centralized logger and cache the internal API base URL
- only wrap responses for internal requests while preserving external payloads and adding URL resolution helpers
- add unit coverage exercising internal vs external API responses

## Testing
- npm run test:frontend

------
https://chatgpt.com/codex/tasks/task_e_68dabbdb8f088324937ed6d82587f627