### PR TITLE
Fix ProtectedRoute redirect handling

### DIFF
--- a/apps/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
-import { ReactNode, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 
 interface ProtectedRouteProps {
@@ -15,20 +15,6 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   const navigate = useNavigate();
   const location = useLocation();
   const hasRequiredPermissions = !adminOnly || isAdmin;
-
-  useEffect(() => {
-    if (!loading) {
-      if (user) {
-        // Usuário autenticado: segue fluxo normal
-        if (!hasRequiredPermissions) {
-          navigate('/', { replace: true });
-        }
-      } else {
-        // Não autenticado: não redireciona automaticamente. Exibimos CTA de login.
-        // Isso evita flakiness nos testes E2E no carregamento inicial.
-      }
-    }
-  }, [loading, user, navigate, location, hasRequiredPermissions]);
 
   // Show loading state while checking authentication
   if (loading) {
@@ -63,7 +49,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   }
 
   if (!hasRequiredPermissions) {
-    return null;
+    return <Navigate to="/" replace state={{ from: location.pathname }} />;
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Summary
- update ProtectedRoute to use synchronous <Navigate> redirects for unauthorized users
- refresh ProtectedRoute tests to assert routing outcomes without mocking useNavigate

## Testing
- npx vitest run src/components/auth/__tests__/ProtectedRoute.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dac20319b08324a598b0a64132c97b