### PR TITLE
Stabilize frontend QueryClient instance

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,26 +10,28 @@ import { AuthProvider } from "@/hooks/useAuth";
 import { AppRoutes } from "@/routes";
 import { ThemeProvider } from "next-themes";
 
-const queryClient = new QueryClient();
+const App = () => {
+  const [queryClient] = useState(() => new QueryClient());
 
-const App = () => (
-  <ErrorBoundary>
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <AuthProvider>
-            <HashRouter>
-              <Suspense fallback={<Loading fullScreen message="Carregando aplicação..." />}>
-                <AppRoutes />
-              </Suspense>
-            </HashRouter>
-          </AuthProvider>
-        </TooltipProvider>
-      </QueryClientProvider>
-    </ThemeProvider>
-  </ErrorBoundary>
-);
+  return (
+    <ErrorBoundary>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <AuthProvider>
+              <HashRouter>
+                <Suspense fallback={<Loading fullScreen message="Carregando aplicação..." />}>
+                  <AppRoutes />
+                </Suspense>
+              </HashRouter>
+            </AuthProvider>
+          </TooltipProvider>
+        </QueryClientProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
+  );
+};
 
 export default App;


### PR DESCRIPTION
## Summary
- create the TanStack Query client lazily with useState to keep a single instance during the app lifecycle

## Testing
- npm --prefix apps/frontend run type-check *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dac6a7f2648324953a3e2c4dbe5a36