### PR TITLE
refactor: consolidate feed routing

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -7,7 +7,6 @@ import cookieParser from 'cookie-parser';
 import apiRoutes from './routes/api';
 // WebSocket opcional em runtime
 let webSocketServer: any = null;
-import feedRoutes from './routes/feed.routes';
 import { errorHandler } from './middleware/errorHandler';
 import { logger } from './services/logger';
 import { pool } from './config/database';
@@ -56,7 +55,6 @@ app.get('/api/csrf-token', (req, res) => {
 
 // Rotas
 app.use('/api', apiRoutes);
-app.use('/api/feed', feedRoutes);
 
 // Documentação OpenAPI/Swagger (apenas em desenvolvimento)
 if (env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Summary
- remove the duplicate feed router mounting from the Express app entry point to keep /api routing centralized

## Testing
- npm --prefix apps/backend run smoke:chat *(fails: fetch failed while trying to log in because the API server is not running in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac6a113e08324b9ddf9b2b59104b9