### PR TITLE
docs: document manual SQL migrations after ORM removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assist Move Assist
 
-Sistema completo de gestão para institutos sociais com acompanhamento de beneficiárias, administração de oficinas/projetos, painel analítico e comunicação interna em tempo real. A stack é composta por **React 18 + Vite** no frontend e **Node.js/Express + PostgreSQL** no backend, com Redis para cache, filas e controle de permissões.
+Sistema completo de gestão para institutos sociais com acompanhamento de beneficiárias, administração de oficinas/projetos, painel analítico e comunicação interna em tempo real. A stack é composta por **React 18 + Vite** no frontend e **Node.js/Express + PostgreSQL** no backend, com Redis para cache, filas e controle de permissões. O ORM Prisma foi removido: o acesso ao banco agora é feito diretamente via SQL com `node-postgres` e scripts versionados neste repositório.
 
 ## Sumário
 
@@ -182,6 +182,13 @@ npm --prefix apps/backend run migrate:node # Migrações + seed automáticos
 npm --prefix apps/backend run test       # Testes unitários backend
 npm run test:e2e            # Playwright (necessita API ativa)
 ```
+
+### Migrações SQL (sem ORM)
+
+- As migrações oficiais residem em `apps/backend/src/database/migrations` e são executadas sem Prisma.
+- Para aplicar todas as migrações pendentes em ambientes Linux/macOS utilize `npm --prefix apps/backend run migrate` (shell Bash) ou `npm --prefix apps/backend run migrate:node` para a versão 100% Node.js que também aplica o seed inicial.
+- Em pipelines CI/CD e ambientes de produção, sempre execute uma das opções acima antes de iniciar o backend para garantir que o schema esteja sincronizado.
+- Caso precise gerar uma nova migração, crie um arquivo `.sql` incremental na pasta `apps/backend/src/database/migrations` seguindo o padrão existente e inclua a instrução correspondente no script de bootstrap se necessário.
 
 ## Testes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,7 @@ O Assist Move Assist é um sistema monorepo baseado em TypeScript, dividido em d
 ### Backend (Node.js + Express)
 - API RESTful com Express
 - Banco de dados PostgreSQL com node-postgres (SQL puro)
+- ORM removido: todo o acesso a dados e migrações é feito via SQL versionado em `apps/backend/src/database/migrations`
 - Cache e filas com Redis
 - WebSocket para notificações em tempo real
 - JWT para autenticação
@@ -84,7 +85,8 @@ assist-move-assist/
 
 3. **Banco de Dados**
    - PostgreSQL para persistência
-   - node-postgres (`pg`) com scripts SQL para migrações
+   - node-postgres (`pg`) com scripts SQL para migrações (sem Prisma)
+   - Migrações versionadas em `apps/backend/src/database/migrations` executadas pelos scripts `npm --prefix apps/backend run migrate` ou `npm --prefix apps/backend run migrate:node`
    - Índices otimizados
    - Conexão com pool
 


### PR DESCRIPTION
## Summary
- clarify in the README that Prisma is no longer part of the stack and that migrations run with raw SQL scripts
- add a dedicated section that details how to apply the existing SQL migrations in different environments
- update the architecture guide to highlight the Prisma removal and reference the scripts used to apply migrations

## Testing
- no tests were run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dac6da669083248a7aa055b78939b1