### PR TITLE
Align WebSocket CORS with backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ assist-move-assist/
    CORS_ORIGIN=http://localhost:5173,http://localhost:4173
    ```
 
+   > A mesma lista é reutilizada para as validações de CORS HTTP e para o handshake do WebSocket.
+
 3. Para ambientes diferentes, mantenha arquivos separados e utilize `ENV_FILE` ao iniciar a API (`ENV_FILE=.env.staging npm --prefix apps/backend run start`).
 
 ## Fluxos de Execução

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -85,6 +85,7 @@
     "@types/zxcvbn": "^4.4.4",
     "factory-girl": "^5.0.4",
     "jest": "^29.7.0",
+    "socket.io-client": "^4.8.1",
     "supertest": "^6.3.3",
     "testcontainers": "^11.5.1",
     "ts-jest": "^29.1.1",

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -56,7 +56,7 @@ const config = {
   websocket: {
     path: '/ws',
     cors: {
-      origin: '*',
+      origin: parseCorsOrigin(env.CORS_ORIGIN),
       methods: ['GET', 'POST'],
     },
   },

--- a/apps/backend/src/websocket/__tests__/websocket.cors.test.ts
+++ b/apps/backend/src/websocket/__tests__/websocket.cors.test.ts
@@ -1,0 +1,162 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import jwt from 'jsonwebtoken';
+import { io as createClient, Socket } from 'socket.io-client';
+import type { Pool } from 'pg';
+
+jest.mock('../../lib/redis', () => ({
+  redis: {
+    lrange: jest.fn().mockResolvedValue([]),
+    lpush: jest.fn().mockResolvedValue(0),
+    del: jest.fn().mockResolvedValue(0),
+    lrem: jest.fn().mockResolvedValue(0),
+    multi: jest.fn(() => ({
+      lpush: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([])
+    }))
+  }
+}));
+
+describe('WebSocket CORS configuration', () => {
+  let WebSocketServer: typeof import('../server').WebSocketServer;
+  let config: typeof import('../../config').config;
+  const userPayload = {
+    id: 'user-123',
+    nome: 'Usuária Teste',
+    email: 'user@example.com'
+  };
+
+  const createPoolStub = () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+    const client = {
+      query: queryMock,
+      on: jest.fn(),
+      release: jest.fn()
+    };
+
+    return {
+      connect: jest.fn().mockResolvedValue(client),
+      query: queryMock
+    } as unknown as Pool;
+  };
+
+  const createToken = (secret: string) =>
+    jwt.sign(userPayload, secret, { expiresIn: '15m' });
+
+  beforeAll(async () => {
+    process.env.CORS_ORIGIN = 'http://allowed.test,http://second.test';
+    jest.resetModules();
+    ({ config } = await import('../../config'));
+    ({ WebSocketServer } = await import('../server'));
+
+    expect(config.websocket.cors.origin).toEqual([
+      'http://allowed.test',
+      'http://second.test'
+    ]);
+  });
+
+  afterAll(() => {
+    delete process.env.CORS_ORIGIN;
+  });
+
+  const connectWithOrigin = (port: number, token: string, origin: string) =>
+    new Promise<Socket>((resolve, reject) => {
+      const headers = {
+        Origin: origin,
+        origin
+      };
+
+      const instance = createClient(`http://localhost:${port}`, {
+        path: config.websocket.path,
+        forceNew: true,
+        reconnection: false,
+        auth: { token },
+        extraHeaders: headers,
+        transportOptions: {
+          polling: { extraHeaders: headers },
+          websocket: { extraHeaders: headers }
+        }
+      });
+
+      instance.on('connect', () => resolve(instance));
+      instance.on('connect_error', reject);
+    });
+
+  it('permite conexões provenientes das origens configuradas', async () => {
+    const httpServer = http.createServer();
+    const wsServer = new WebSocketServer(httpServer, createPoolStub());
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+    const { port } = httpServer.address() as AddressInfo;
+
+    const token = createToken(config.jwt.secret);
+
+    try {
+      const seenOrigins: Array<string | undefined> = [];
+      ((wsServer as any).io.engine as any).on('headers', (_headers: unknown, req: any) => {
+        seenOrigins.push(req.headers.origin as string | undefined);
+      });
+
+      const client = await connectWithOrigin(port, token, 'http://allowed.test');
+
+      client.disconnect();
+      expect(seenOrigins).toContain('http://allowed.test');
+    } finally {
+      await new Promise<void>((resolve) => (wsServer as any).io.close(() => resolve()));
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  });
+
+  it('rejeita conexões de origens não autorizadas', async () => {
+    const httpServer = http.createServer();
+    const wsServer = new WebSocketServer(httpServer, createPoolStub());
+    await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+    const { port } = httpServer.address() as AddressInfo;
+
+    const token = createToken(config.jwt.secret);
+
+    try {
+      const error = await new Promise<Error>((resolve) => {
+        const headers = {
+          Origin: 'http://malicious.test',
+          origin: 'http://malicious.test'
+        };
+
+        const instance = createClient(`http://localhost:${port}`, {
+          path: config.websocket.path,
+          forceNew: true,
+          reconnection: false,
+          auth: { token },
+          extraHeaders: headers,
+          transportOptions: {
+            polling: { extraHeaders: headers },
+            websocket: { extraHeaders: headers }
+          }
+        });
+
+        instance.on('connect', () => {
+          instance.disconnect();
+          resolve(new Error('Connection should have been rejected'));
+        });
+
+        instance.on('connect_error', (err) => {
+          instance.disconnect();
+          resolve(err instanceof Error ? err : new Error(String(err)));
+        });
+      });
+
+      expect(error.message).toMatch(/xhr poll error/i);
+
+      const responseText = (error as any)?.context?.responseText;
+      if (typeof responseText === 'string' && responseText.length > 0) {
+        const payload = JSON.parse(responseText);
+        expect(payload.message).toMatch(/CORS: Origin not allowed/);
+      } else if ((error as any)?.data?.message) {
+        expect((error as any).data.message).toMatch(/CORS: Origin not allowed/);
+      }
+    } finally {
+      await new Promise<void>((resolve) => (wsServer as any).io.close(() => resolve()));
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  });
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,6 +105,7 @@ assist-move-assist/
    ```
    Cliente <-> WS Server <-> Redis PubSub <-> Service
    ```
+   - O handshake aplica o mesmo `CORS_ORIGIN` da API, aceitando múltiplas origens separadas por vírgula.
 
 3. **Cache**
    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "factory-girl": "^5.0.4",
         "globals": "^15.12.0",
         "jest": "^29.7.0",
+        "socket.io-client": "^4.8.1",
         "supertest": "^6.3.3",
         "testcontainers": "^11.5.1",
         "ts-jest": "^29.1.1",


### PR DESCRIPTION
## Summary
- reuse the existing CORS origin parser for the WebSocket configuration
- enforce the parsed origins when instantiating the Socket.IO server and add targeted tests
- document how to configure multiple WebSocket origins and add socket.io-client as a dev dependency

## Testing
- npm test -- websocket.cors.test.ts (apps/backend)


------
https://chatgpt.com/codex/tasks/task_e_68dac6a5321c83248788a6a1786b3e36