### PR TITLE
feat: integrate messaging hook with widget

### DIFF
--- a/apps/frontend/src/components/__tests__/MessagingWidget.test.tsx
+++ b/apps/frontend/src/components/__tests__/MessagingWidget.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+
+const socketListeners: Array<(message: any) => void> = [];
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 1, nome: 'Usuário Atual', nome_completo: 'Usuário Atual' },
+    profile: { id: 1, nome: 'Usuário Atual', nome_completo: 'Usuário Atual' },
+    loading: false,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    isAuthenticated: true,
+    isAdmin: false,
+  }),
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  default: () => ({
+    socket: null,
+    isConnected: true,
+    addMessageListener: (callback: (message: any) => void) => {
+      socketListeners.push(callback);
+      return () => {
+        const index = socketListeners.indexOf(callback);
+        if (index >= 0) {
+          socketListeners.splice(index, 1);
+        }
+      };
+    },
+  }),
+}));
+
+import MessagingWidget from '../MessagingWidget';
+import { apiService } from '@/services/apiService';
+
+describe('MessagingWidget', () => {
+  const getUsuariosConversaMock = vi.spyOn(apiService, 'getUsuariosConversa');
+  const getConversasUsuarioMock = vi.spyOn(apiService, 'getConversasUsuario');
+  const getMensagensUsuarioMock = vi.spyOn(apiService, 'getMensagensUsuario');
+  const enviarMensagemUsuarioMock = vi.spyOn(apiService, 'enviarMensagemUsuario');
+
+  const renderComponent = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MessagingWidget />
+      </QueryClientProvider>
+    );
+  };
+
+  const mockUsers = [
+    { id: 2, nome_completo: 'Ana Maria' },
+    { id: 3, nome: 'Carlos Souza' },
+  ];
+
+  const mockConversations = [
+    {
+      id: 101,
+      autor_id: 2,
+      autor_nome: 'Ana Maria',
+      destinatario_id: 1,
+      destinatario_nome: 'Usuário Atual',
+      conteudo: 'Olá, tudo bem?',
+      data_publicacao: '2024-05-01T10:00:00Z',
+      lida: false,
+    },
+  ];
+
+  const mockMessagesByUser: Record<number, any[]> = {
+    2: [
+      {
+        id: 1001,
+        autor_id: 2,
+        autor_nome: 'Ana Maria',
+        destinatario_id: 1,
+        destinatario_nome: 'Usuário Atual',
+        conteudo: 'Olá, tudo bem?',
+        data_publicacao: '2024-05-01T10:00:00Z',
+        lida: false,
+      },
+      {
+        id: 1002,
+        autor_id: 1,
+        autor_nome: 'Usuário Atual',
+        destinatario_id: 2,
+        destinatario_nome: 'Ana Maria',
+        conteudo: 'Oi Ana!',
+        data_publicacao: '2024-05-01T11:00:00Z',
+        lida: true,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    socketListeners.length = 0;
+    (window.HTMLElement.prototype.scrollIntoView as any) = vi.fn();
+
+    getUsuariosConversaMock.mockResolvedValue({ success: true, data: mockUsers });
+    getConversasUsuarioMock.mockResolvedValue({ success: true, data: mockConversations });
+    getMensagensUsuarioMock.mockImplementation(async (usuarioId: number) => ({
+      success: true,
+      data: mockMessagesByUser[usuarioId] ?? [],
+    }));
+    enviarMensagemUsuarioMock.mockImplementation(async ({ destinatario_id, conteudo }: any) => ({
+      success: true,
+      data: {
+        id: 2001,
+        autor_id: 1,
+        autor_nome: 'Usuário Atual',
+        destinatario_id,
+        destinatario_nome: destinatario_id === 2 ? 'Ana Maria' : 'Usuário',
+        conteudo,
+        data_publicacao: '2024-05-01T12:00:00Z',
+        lida: true,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    socketListeners.length = 0;
+  });
+
+  it('exibe conversas, carrega mensagens e sincroniza com eventos do socket', async () => {
+    renderComponent();
+
+    const openButton = screen.getByRole('button', { name: /abrir mensagens/i });
+    fireEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Ana Maria')).toBeInTheDocument();
+    });
+
+    const conversationButton = screen.getByText('Ana Maria');
+    fireEvent.click(conversationButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Olá, tudo bem?')).toBeInTheDocument();
+      expect(screen.getByText('Oi Ana!')).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText('Digite sua mensagem...');
+    fireEvent.change(input, { target: { value: 'Mensagem enviada pelo usuário atual' } });
+
+    const sendButton = screen.getByRole('button', { name: /enviar mensagem/i });
+    fireEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(enviarMensagemUsuarioMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Mensagem enviada pelo usuário atual')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      socketListeners.forEach((listener) => {
+        listener({
+          id: 3001,
+          autor_id: 2,
+          autor_nome: 'Ana Maria',
+          destinatario_id: 1,
+          destinatario_nome: 'Usuário Atual',
+          conteudo: 'Mensagem em tempo real',
+          data_publicacao: '2024-05-01T12:30:00Z',
+          lida: false,
+        });
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Mensagem em tempo real')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/hooks/useMessaging.ts
+++ b/apps/frontend/src/hooks/useMessaging.ts
@@ -1,0 +1,629 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiService } from '@/services/apiService';
+import useSocket from './useSocket';
+import { useAuth } from './useAuth';
+
+const messagingKeys = {
+  conversations: ['messaging', 'conversations'] as const,
+  users: ['messaging', 'users'] as const,
+  messages: (conversationId: string | null) => ['messaging', 'messages', conversationId] as const,
+};
+
+type RawMessage = Record<string, any>;
+
+type ConversationType = 'individual' | 'grupo';
+
+export interface MessagingParticipant {
+  user_id: string;
+  nome_completo: string;
+}
+
+export interface MessagingConversation {
+  id: string;
+  tipo: ConversationType;
+  nome_grupo?: string;
+  participants: MessagingParticipant[];
+  last_message?: {
+    conteudo: string;
+    created_at: string;
+    sender_name: string;
+  };
+  unread_count: number;
+}
+
+export interface MessagingMessage {
+  id: string;
+  conteudo: string;
+  sender_id: string;
+  sender_name: string;
+  created_at: string;
+  editada: boolean;
+}
+
+export interface MessagingUserOption {
+  id: string;
+  nome_completo: string;
+  raw?: Record<string, any>;
+}
+
+export interface UseMessagingOptions {
+  enabled?: boolean;
+}
+
+const ensureError = (error: unknown): Error | null => {
+  if (!error) return null;
+  return error instanceof Error ? error : new Error(typeof error === 'string' ? error : 'Erro desconhecido');
+};
+
+const normaliseId = (value: any): string | null => {
+  if (value === null || value === undefined) return null;
+  if (Number.isNaN(value)) return null;
+  const parsed = typeof value === 'string' ? value.trim() : String(value);
+  return parsed.length > 0 ? parsed : null;
+};
+
+const normaliseName = (value: any, fallback = 'Usuário'): string => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  return fallback;
+};
+
+const getAuthorId = (message: RawMessage): string | null => {
+  return (
+    normaliseId(message.autor_id)
+    ?? normaliseId(message.remetente_id)
+    ?? normaliseId(message.autorId)
+    ?? normaliseId(message.author_id)
+    ?? normaliseId(message.sender_id)
+  );
+};
+
+const getRecipientId = (message: RawMessage): string | null => {
+  return (
+    normaliseId(message.destinatario_id)
+    ?? normaliseId(message.destinatarioId)
+    ?? normaliseId(message.receiver_id)
+    ?? normaliseId(message.recebedor_id)
+  );
+};
+
+const getAuthorName = (message: RawMessage, fallback = 'Usuário'): string => {
+  return normaliseName(
+    message.autor_nome
+      ?? message.remetente_nome
+      ?? message.autorNome
+      ?? message.sender_name
+      ?? message.senderName,
+    fallback
+  );
+};
+
+const getRecipientName = (message: RawMessage, fallback = 'Usuário'): string => {
+  return normaliseName(
+    message.destinatario_nome
+      ?? message.destinatarioNome
+      ?? message.receiver_name
+      ?? message.receiverName,
+    fallback
+  );
+};
+
+const getCreatedAt = (message: RawMessage): string => {
+  return (
+    message.data_publicacao
+    ?? message.data_criacao
+    ?? message.created_at
+    ?? message.createdAt
+    ?? new Date().toISOString()
+  );
+};
+
+const toMessagingMessage = (
+  message: RawMessage,
+  currentUserId: string | null,
+  currentUserName: string
+): MessagingMessage => {
+  const senderId = getAuthorId(message) ?? currentUserId ?? '0';
+  const senderName = getAuthorName(
+    message,
+    currentUserId && senderId === currentUserId ? currentUserName : 'Usuário'
+  );
+
+  return {
+    id: normaliseId(message.id) ?? `${Date.now()}`,
+    conteudo: typeof message.conteudo === 'string' ? message.conteudo : '',
+    sender_id: senderId,
+    sender_name: senderName,
+    created_at: getCreatedAt(message),
+    editada: Boolean(message.editada ?? message.atualizada ?? message.updated_at),
+  };
+};
+
+const mergeParticipants = (
+  a: MessagingParticipant[],
+  b: MessagingParticipant[],
+): MessagingParticipant[] => {
+  const map = new Map<string, MessagingParticipant>();
+  [...a, ...b].forEach((participant) => {
+    if (!participant?.user_id) return;
+    const existing = map.get(participant.user_id);
+    if (!existing || normaliseName(participant.nome_completo) !== 'Usuário') {
+      map.set(participant.user_id, {
+        user_id: participant.user_id,
+        nome_completo: normaliseName(
+          participant.nome_completo,
+          existing?.nome_completo ?? 'Usuário'
+        ),
+      });
+    }
+  });
+  return Array.from(map.values());
+};
+
+const buildConversationFromMessage = (
+  message: RawMessage,
+  currentUserId: string | null,
+  currentUserName: string
+): MessagingConversation | null => {
+  const authorId = getAuthorId(message);
+  const recipientId = getRecipientId(message);
+  const baseParticipants: MessagingParticipant[] = [];
+
+  if (authorId) {
+    baseParticipants.push({
+      user_id: authorId,
+      nome_completo: getAuthorName(
+        message,
+        currentUserId && authorId === currentUserId ? currentUserName : 'Usuário'
+      ),
+    });
+  }
+
+  if (recipientId) {
+    baseParticipants.push({
+      user_id: recipientId,
+      nome_completo: getRecipientName(
+        message,
+        currentUserId && recipientId === currentUserId ? currentUserName : 'Usuário'
+      ),
+    });
+  }
+
+  if (currentUserId && !baseParticipants.find((participant) => participant.user_id === currentUserId)) {
+    baseParticipants.push({ user_id: currentUserId, nome_completo: currentUserName });
+  }
+
+  const participants = mergeParticipants(baseParticipants, []);
+
+  if (participants.length === 0) {
+    return null;
+  }
+
+  const senderId = getAuthorId(message);
+  const conversationId = currentUserId
+    ? (senderId && senderId !== currentUserId
+        ? senderId
+        : recipientId && recipientId !== currentUserId
+          ? recipientId
+          : senderId ?? recipientId ?? normaliseId(message.thread_id) ?? normaliseId(message.id)
+      )
+    : senderId ?? recipientId ?? normaliseId(message.thread_id) ?? normaliseId(message.id);
+
+  if (!conversationId) {
+    return null;
+  }
+
+  const lastMessage = toMessagingMessage(message, currentUserId, currentUserName);
+  const isIncoming = currentUserId ? lastMessage.sender_id !== currentUserId : false;
+  const recipientMatchesCurrent = currentUserId ? recipientId === currentUserId : false;
+  const unreadCount = isIncoming && recipientMatchesCurrent && message.lida === false ? 1 : 0;
+
+  return {
+    id: conversationId,
+    tipo: 'individual',
+    participants,
+    last_message: {
+      conteudo: lastMessage.conteudo,
+      created_at: lastMessage.created_at,
+      sender_name: lastMessage.sender_name,
+    },
+    unread_count: unreadCount,
+  };
+};
+
+export const useMessaging = ({ enabled = true }: UseMessagingOptions = {}) => {
+  const { user } = useAuth();
+  const { addMessageListener } = useSocket();
+  const queryClient = useQueryClient();
+  const currentUserId = user?.id !== undefined ? normaliseId(user.id) : null;
+  const currentUserName = useMemo(
+    () => normaliseName(user?.nome_completo ?? user?.nome ?? 'Você', 'Você'),
+    [user?.nome, user?.nome_completo]
+  );
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const selectedConversationIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    selectedConversationIdRef.current = selectedConversationId;
+  }, [selectedConversationId]);
+
+  const effectiveEnabled = enabled && Boolean(currentUserId);
+
+  const usersQuery = useQuery({
+    queryKey: messagingKeys.users,
+    enabled: effectiveEnabled,
+    queryFn: async () => {
+      const response = await apiService.getUsuariosConversa();
+      if (!response.success) {
+        throw new Error(response.message ?? 'Erro ao carregar usuários');
+      }
+      const rawUsers = Array.isArray(response.data) ? response.data : [];
+      return rawUsers.map((rawUser: any): MessagingUserOption => ({
+        id: normaliseId(rawUser.id ?? rawUser.user_id ?? rawUser.usuario_id) ?? '',
+        nome_completo: normaliseName(rawUser.nome_completo ?? rawUser.nome ?? rawUser.name),
+        raw: rawUser,
+      }));
+    },
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const conversationsQuery = useQuery({
+    queryKey: messagingKeys.conversations,
+    enabled: effectiveEnabled,
+    queryFn: async () => {
+      const response = await apiService.getConversasUsuario();
+      if (!response.success) {
+        throw new Error(response.message ?? 'Erro ao carregar conversas');
+      }
+      const rows = Array.isArray(response.data) ? response.data : [];
+      const map = new Map<string, MessagingConversation>();
+
+      rows.forEach((row) => {
+        const conversation = buildConversationFromMessage(row, currentUserId, currentUserName);
+        if (!conversation) {
+          return;
+        }
+
+        const existing = map.get(conversation.id);
+        if (!existing) {
+          map.set(conversation.id, conversation);
+          return;
+        }
+
+        const updatedParticipants = mergeParticipants(existing.participants, conversation.participants);
+        const existingTime = Date.parse(existing.last_message?.created_at ?? '') || 0;
+        const newTime = Date.parse(conversation.last_message?.created_at ?? '') || 0;
+
+        if (newTime >= existingTime) {
+          map.set(conversation.id, {
+            ...conversation,
+            participants: updatedParticipants,
+            unread_count: Math.max(existing.unread_count, conversation.unread_count),
+          });
+        } else {
+          map.set(conversation.id, {
+            ...existing,
+            participants: updatedParticipants,
+            unread_count: Math.max(existing.unread_count, conversation.unread_count),
+          });
+        }
+      });
+
+      return Array.from(map.values()).sort((a, b) => {
+        const aTime = Date.parse(a.last_message?.created_at ?? '') || 0;
+        const bTime = Date.parse(b.last_message?.created_at ?? '') || 0;
+        return bTime - aTime;
+      });
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const messagesQuery = useQuery({
+    queryKey: messagingKeys.messages(selectedConversationId),
+    enabled: effectiveEnabled && Boolean(selectedConversationId),
+    queryFn: async () => {
+      if (!selectedConversationId) {
+        return [] as MessagingMessage[];
+      }
+
+      const destinatarioIdNumber = Number(selectedConversationId);
+      if (!Number.isFinite(destinatarioIdNumber)) {
+        throw new Error('Conversa inválida');
+      }
+
+      const response = await apiService.getMensagensUsuario(destinatarioIdNumber);
+      if (!response.success) {
+        throw new Error(response.message ?? 'Erro ao carregar mensagens');
+      }
+      const rows = Array.isArray(response.data) ? response.data : [];
+      return rows
+        .map((row) => toMessagingMessage(row, currentUserId, currentUserName))
+        .sort((a, b) => {
+          const aTime = Date.parse(a.created_at) || 0;
+          const bTime = Date.parse(b.created_at) || 0;
+          return aTime - bTime;
+        });
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  const sendMessageMutation = useMutation({
+    mutationFn: async ({ conversationId, conteudo }: { conversationId: string; conteudo: string }) => {
+      const destinatarioIdNumber = Number(conversationId);
+      if (!Number.isFinite(destinatarioIdNumber)) {
+        throw new Error('Conversa inválida');
+      }
+
+      const response = await apiService.enviarMensagemUsuario({
+        destinatario_id: destinatarioIdNumber,
+        conteudo,
+      });
+
+      if (!response.success) {
+        throw new Error(response.message ?? 'Erro ao enviar mensagem');
+      }
+
+      return response.data as RawMessage;
+    },
+    onSuccess: (message) => {
+      if (!message) return;
+      const conversationId = buildConversationFromMessage(message, currentUserId, currentUserName)?.id;
+      if (!conversationId) return;
+
+      const mappedMessage = toMessagingMessage(message, currentUserId, currentUserName);
+
+      queryClient.setQueryData<MessagingMessage[] | undefined>(
+        messagingKeys.messages(conversationId),
+        (existing = []) => {
+          if (existing.some((item) => item.id === mappedMessage.id)) {
+            return existing;
+          }
+          return [...existing, mappedMessage].sort((a, b) => {
+            const aTime = Date.parse(a.created_at) || 0;
+            const bTime = Date.parse(b.created_at) || 0;
+            return aTime - bTime;
+          });
+        }
+      );
+
+      queryClient.setQueryData<MessagingConversation[] | undefined>(
+        messagingKeys.conversations,
+        (existing = []) => {
+          const conversationFromMessage = buildConversationFromMessage(message, currentUserId, currentUserName);
+          if (!conversationFromMessage) {
+            return existing;
+          }
+
+          const conversations = [...existing];
+          const index = conversations.findIndex((conversation) => conversation.id === conversationId);
+          if (index === -1) {
+            conversations.unshift({
+              ...conversationFromMessage,
+              unread_count: 0,
+            });
+            return conversations;
+          }
+
+          const current = conversations[index];
+          conversations[index] = {
+            ...current,
+            participants: mergeParticipants(current.participants, conversationFromMessage.participants),
+            last_message: conversationFromMessage.last_message,
+            unread_count: 0,
+          };
+
+          conversations.sort((a, b) => {
+            const aTime = Date.parse(a.last_message?.created_at ?? '') || 0;
+            const bTime = Date.parse(b.last_message?.created_at ?? '') || 0;
+            return bTime - aTime;
+          });
+
+          return conversations;
+        }
+      );
+    },
+  });
+
+  const selectConversation = useCallback((conversationId: string | null) => {
+    setSelectedConversationId(conversationId);
+    if (!conversationId) {
+      return;
+    }
+
+    queryClient.setQueryData<MessagingConversation[] | undefined>(
+      messagingKeys.conversations,
+      (existing = []) => existing.map((conversation) => (
+        conversation.id === conversationId
+          ? { ...conversation, unread_count: 0 }
+          : conversation
+      ))
+    );
+  }, [queryClient]);
+
+  const createConversation = useCallback(
+    async (selectedUsers: string[], isGroup: boolean, groupName?: string) => {
+      if (isGroup) {
+        console.warn('Conversa em grupo ainda não é suportada.');
+        return;
+      }
+
+      const targetId = selectedUsers[0];
+      if (!targetId) {
+        return;
+      }
+
+      const normalizedTargetId = normaliseId(targetId);
+      if (!normalizedTargetId) {
+        return;
+      }
+
+      selectConversation(normalizedTargetId);
+
+      queryClient.setQueryData<MessagingConversation[] | undefined>(
+        messagingKeys.conversations,
+        (existing = []) => {
+          if (existing.some((conversation) => conversation.id === normalizedTargetId)) {
+            return existing;
+          }
+
+          const targetUser = usersQuery.data?.find((userOption) => userOption.id === normalizedTargetId);
+          const participants: MessagingParticipant[] = [];
+
+          if (currentUserId) {
+            participants.push({ user_id: currentUserId, nome_completo: currentUserName });
+          }
+
+          if (targetUser) {
+            participants.push({ user_id: normalizedTargetId, nome_completo: targetUser.nome_completo });
+          } else {
+            participants.push({ user_id: normalizedTargetId, nome_completo: 'Usuário' });
+          }
+
+          return [
+            {
+              id: normalizedTargetId,
+              tipo: 'individual',
+              participants,
+              unread_count: 0,
+            },
+            ...existing,
+          ];
+        }
+      );
+    },
+    [currentUserId, currentUserName, queryClient, selectConversation, usersQuery.data]
+  );
+
+  const sendMessage = useCallback(
+    async (conversationId: string, conteudo: string) => {
+      if (!conteudo.trim()) {
+        return;
+      }
+      await sendMessageMutation.mutateAsync({ conversationId, conteudo: conteudo.trim() });
+    },
+    [sendMessageMutation]
+  );
+
+  const updateCachesFromIncomingMessage = useCallback((message: RawMessage) => {
+    const conversation = buildConversationFromMessage(message, currentUserId, currentUserName);
+    if (!conversation) return;
+
+    const mappedMessage = toMessagingMessage(message, currentUserId, currentUserName);
+    const conversationId = conversation.id;
+    const selectedId = selectedConversationIdRef.current;
+    const isIncoming = currentUserId ? mappedMessage.sender_id !== currentUserId : true;
+
+    queryClient.setQueryData<MessagingMessage[] | undefined>(
+      messagingKeys.messages(conversationId),
+      (existing = []) => {
+        if (existing.some((item) => item.id === mappedMessage.id)) {
+          return existing;
+        }
+        return [...existing, mappedMessage].sort((a, b) => {
+          const aTime = Date.parse(a.created_at) || 0;
+          const bTime = Date.parse(b.created_at) || 0;
+          return aTime - bTime;
+        });
+      }
+    );
+
+    queryClient.setQueryData<MessagingConversation[] | undefined>(
+      messagingKeys.conversations,
+      (existing = []) => {
+        const conversations = [...existing];
+        const index = conversations.findIndex((item) => item.id === conversationId);
+        if (index === -1) {
+          conversations.unshift({
+            ...conversation,
+            unread_count: isIncoming && conversationId !== selectedId ? Math.max(conversation.unread_count, 1) : 0,
+          });
+          return conversations;
+        }
+
+        const current = conversations[index];
+        const unreadCount = isIncoming && conversationId !== selectedId
+          ? current.unread_count + 1
+          : 0;
+
+        conversations[index] = {
+          ...current,
+          participants: mergeParticipants(current.participants, conversation.participants),
+          last_message: conversation.last_message,
+          unread_count: unreadCount,
+        };
+
+        conversations.sort((a, b) => {
+          const aTime = Date.parse(a.last_message?.created_at ?? '') || 0;
+          const bTime = Date.parse(b.last_message?.created_at ?? '') || 0;
+          return bTime - aTime;
+        });
+
+        return conversations;
+      }
+    );
+  }, [currentUserId, currentUserName, queryClient]);
+
+  useEffect(() => {
+    if (!effectiveEnabled) {
+      return undefined;
+    }
+
+    const removeListener = addMessageListener?.((message: RawMessage) => {
+      updateCachesFromIncomingMessage(message);
+    });
+
+    return () => {
+      removeListener?.();
+    };
+  }, [addMessageListener, effectiveEnabled, updateCachesFromIncomingMessage]);
+
+  const usersLookup = useMemo(() => {
+    const lookup = new Map<string, string>();
+    (usersQuery.data ?? []).forEach((userOption) => {
+      lookup.set(userOption.id, userOption.nome_completo);
+    });
+    return lookup;
+  }, [usersQuery.data]);
+
+  const conversations = useMemo(() => {
+    return (conversationsQuery.data ?? []).map((conversation) => ({
+      ...conversation,
+      participants: conversation.participants.map((participant) => ({
+        ...participant,
+        nome_completo: participant.nome_completo !== 'Usuário'
+          ? participant.nome_completo
+          : usersLookup.get(participant.user_id) ?? participant.nome_completo,
+      })),
+    }));
+  }, [conversationsQuery.data, usersLookup]);
+
+  const selectedConversation = useMemo(
+    () => conversations.find((conversation) => conversation.id === selectedConversationId) ?? null,
+    [conversations, selectedConversationId]
+  );
+
+  return {
+    conversations,
+    users: usersQuery.data ?? [],
+    messages: messagesQuery.data ?? [],
+    selectedConversation,
+    selectedConversationId,
+    selectConversation,
+    createConversation,
+    sendMessage,
+    isSendingMessage: sendMessageMutation.isPending,
+    isLoadingConversations: conversationsQuery.isPending,
+    conversationsError: ensureError(conversationsQuery.error),
+    isLoadingUsers: usersQuery.isPending,
+    usersError: ensureError(usersQuery.error),
+    isLoadingMessages: messagesQuery.isPending,
+    messagesError: ensureError(messagesQuery.error),
+    refetchConversations: conversationsQuery.refetch,
+  };
+};
+
+export default useMessaging;


### PR DESCRIPTION
## Summary
- add a reusable `useMessaging` hook that fetches conversations/users/messages with React Query and syncs socket updates
- refactor `MessagingWidget` to use the new hook, surface loading and error states, and streamline the UI logic
- add an integration test that mocks the API and socket events to validate the messaging flow end-to-end

## Testing
- npx vitest run src/components/__tests__/MessagingWidget.test.tsx --reporter verbose

------
https://chatgpt.com/codex/tasks/task_e_68dac6b7453483249bdced7adc5f0777