### PR TITLE
Add retention controls for unread redis lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ assist-move-assist/
    # DATABASE_URL=postgresql://assistmove:assistmove123@localhost:5432/assist_move_assist # opcional (scripts/e2e)
    REDIS_HOST=127.0.0.1
    REDIS_PORT=6379
+   # Retenção das listas de não lidos (defaults: 30 dias ou 200 itens)
+   REDIS_UNREAD_TTL_SECONDS=2592000
+   REDIS_UNREAD_MAX_ITEMS=200
   CORS_ORIGIN=http://localhost:5173
   ```
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -23,6 +23,8 @@ POSTGRES_PASSWORD=assistmove123
 # Redis
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
+REDIS_UNREAD_TTL_SECONDS=2592000 # 30 dias
+REDIS_UNREAD_MAX_ITEMS=200 # mantém até 200 mensagens/notificações por usuário
 
 # WebSocket
 ENABLE_WS=true

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -84,6 +84,8 @@ const envSchema = z.object({
   POSTGRES_PASSWORD: z.string().min(1, 'POSTGRES_PASSWORD é obrigatório'),
   REDIS_HOST: z.string().optional(),
   REDIS_PORT: z.coerce.number().optional(),
+  REDIS_UNREAD_TTL_SECONDS: z.coerce.number().int().min(0).optional(),
+  REDIS_UNREAD_MAX_ITEMS: z.coerce.number().int().min(0).optional(),
   SMTP_HOST: z.string().optional(),
   SMTP_PORT: z.coerce.number().optional(),
   SMTP_SECURE: booleanFromEnv.optional(),

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -42,6 +42,10 @@ const config = {
   redis: {
     host: env.REDIS_HOST || 'localhost',
     port: env.REDIS_PORT || 6379,
+    unreadRetention: {
+      ttlSeconds: env.REDIS_UNREAD_TTL_SECONDS ?? 60 * 60 * 24 * 30,
+      maxItems: env.REDIS_UNREAD_MAX_ITEMS ?? 200,
+    },
   },
 
   // Configurações do JWT

--- a/apps/backend/src/lib/redis.ts
+++ b/apps/backend/src/lib/redis.ts
@@ -6,14 +6,34 @@ type Primitive = string | number | null;
 
 class InMemoryRedis {
   private kv = new Map<string, { value: string; expiresAt?: number }>();
-  private lists = new Map<string, string[]>();
-  private hashes = new Map<string, Map<string, string>>();
+  private lists = new Map<string, { values: string[]; expiresAt?: number }>();
+  private hashes = new Map<string, { values: Map<string, string>; expiresAt?: number }>();
 
   private isExpired(key: string) {
     const entry = this.kv.get(key);
     if (!entry) return false;
     if (entry.expiresAt && Date.now() > entry.expiresAt) {
       this.kv.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  private isListExpired(key: string) {
+    const entry = this.lists.get(key);
+    if (!entry) return false;
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this.lists.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  private isHashExpired(key: string) {
+    const entry = this.hashes.get(key);
+    if (!entry) return false;
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this.hashes.delete(key);
       return true;
     }
     return false;
@@ -45,18 +65,34 @@ class InMemoryRedis {
   }
 
   async ttl(key: string): Promise<number> {
-    if (this.isExpired(key)) {
+    if (this.isExpired(key) || this.isListExpired(key) || this.isHashExpired(key)) {
       return -2;
     }
     const entry = this.kv.get(key);
-    if (!entry) {
-      return -2;
+    if (entry) {
+      if (!entry.expiresAt) {
+        return -1;
+      }
+      const remaining = Math.ceil((entry.expiresAt - Date.now()) / 1000);
+      return remaining <= 0 ? -2 : remaining;
     }
-    if (!entry.expiresAt) {
-      return -1;
+    const listEntry = this.lists.get(key);
+    if (listEntry) {
+      if (!listEntry.expiresAt) {
+        return -1;
+      }
+      const remaining = Math.ceil((listEntry.expiresAt - Date.now()) / 1000);
+      return remaining <= 0 ? -2 : remaining;
     }
-    const remaining = Math.ceil((entry.expiresAt - Date.now()) / 1000);
-    return remaining <= 0 ? -2 : remaining;
+    const hashEntry = this.hashes.get(key);
+    if (hashEntry) {
+      if (!hashEntry.expiresAt) {
+        return -1;
+      }
+      const remaining = Math.ceil((hashEntry.expiresAt - Date.now()) / 1000);
+      return remaining <= 0 ? -2 : remaining;
+    }
+    return -2;
   }
 
   async del(...keys: string[] | [string[]]): Promise<number> {
@@ -79,7 +115,7 @@ class InMemoryRedis {
       ...Array.from(this.hashes.keys())
     ]
       .filter((k, i, arr) => arr.indexOf(k) === i)
-      .filter((k) => !this.isExpired(k))
+      .filter((k) => !this.isExpired(k) && !this.isListExpired(k) && !this.isHashExpired(k))
       .filter((k) => rx.test(k));
   }
 
@@ -93,7 +129,7 @@ class InMemoryRedis {
     ].filter((k, idx, arr) => arr.indexOf(k) === idx);
 
     const filtered = uniqueKeys.filter((key) => {
-      if (this.isExpired(key)) {
+      if (this.isExpired(key) || this.isListExpired(key) || this.isHashExpired(key)) {
         return false;
       }
       return rx.test(key);
@@ -113,35 +149,65 @@ class InMemoryRedis {
   }
 
   async expire(key: string, seconds: number): Promise<number> {
-    const entry = this.kv.get(key);
-    if (!entry) return 0;
-    entry.expiresAt = Date.now() + seconds * 1000;
-    this.kv.set(key, entry);
-    return 1;
+    const ttl = seconds * 1000;
+    const now = Date.now();
+    const kvEntry = this.kv.get(key);
+    if (kvEntry) {
+      kvEntry.expiresAt = now + ttl;
+      this.kv.set(key, kvEntry);
+      return 1;
+    }
+    const listEntry = this.lists.get(key);
+    if (listEntry) {
+      listEntry.expiresAt = now + ttl;
+      this.lists.set(key, listEntry);
+      return 1;
+    }
+    const hashEntry = this.hashes.get(key);
+    if (hashEntry) {
+      hashEntry.expiresAt = now + ttl;
+      this.hashes.set(key, hashEntry);
+      return 1;
+    }
+    return 0;
   }
 
   async lpush(key: string, value: string): Promise<number> {
-    const arr = this.lists.get(key) || [];
-    arr.unshift(value);
-    this.lists.set(key, arr);
-    return arr.length;
+    const entry = this.lists.get(key);
+    if (!entry || this.isListExpired(key)) {
+      const values = [value];
+      this.lists.set(key, { values });
+      return values.length;
+    }
+    entry.values.unshift(value);
+    this.lists.set(key, entry);
+    return entry.values.length;
   }
 
   async lrange(key: string, start: number, stop: number): Promise<string[]> {
-    const arr = this.lists.get(key) || [];
+    const entry = this.lists.get(key);
+    if (!entry || this.isListExpired(key)) {
+      return [];
+    }
+    const arr = entry.values;
     const end = stop === -1 ? arr.length : stop + 1;
     return arr.slice(start, end);
   }
 
   async lrem(key: string, count: number, value: string): Promise<number> {
-    const arr = this.lists.get(key) || [];
+    const entry = this.lists.get(key);
+    if (!entry || this.isListExpired(key)) {
+      return 0;
+    }
+    const arr = entry.values;
     let removed = 0;
     if (count === 0) {
       const filtered = arr.filter((v) => {
         if (v === value) { removed++; return false; }
         return true;
       });
-      this.lists.set(key, filtered);
+      entry.values = filtered;
+      this.lists.set(key, entry);
       return removed;
     }
     const newArr: string[] = [];
@@ -149,19 +215,33 @@ class InMemoryRedis {
       if (v === value && removed < Math.abs(count)) { removed++; continue; }
       newArr.push(v);
     }
-    this.lists.set(key, newArr);
+    entry.values = newArr;
+    this.lists.set(key, entry);
     return removed;
+  }
+
+  async ltrim(key: string, start: number, stop: number): Promise<'OK'> {
+    const entry = this.lists.get(key);
+    if (!entry || this.isListExpired(key)) {
+      return 'OK';
+    }
+    const arr = entry.values;
+    const end = stop === -1 ? arr.length : stop + 1;
+    entry.values = arr.slice(start, end);
+    this.lists.set(key, entry);
+    return 'OK';
   }
 
   async hset(key: string, field: string, value: Primitive): Promise<number> {
     const str = value === null ? 'null' : String(value);
-    let hash = this.hashes.get(key);
-    if (!hash) {
-      hash = new Map();
-      this.hashes.set(key, hash);
+    let entry = this.hashes.get(key);
+    if (!entry || this.isHashExpired(key)) {
+      entry = { values: new Map() };
+      this.hashes.set(key, entry);
     }
-    const existed = hash.has(field);
-    hash.set(field, str);
+    const existed = entry.values.has(field);
+    entry.values.set(field, str);
+    this.hashes.set(key, entry);
     return existed ? 0 : 1;
   }
 
@@ -172,6 +252,7 @@ class InMemoryRedis {
       setex(key: string, seconds: number, value: Primitive) { ops.push(() => self.setex(key, seconds, value)); return this; },
       del(...keys: string[]) { ops.push(() => self.del(...keys)); return this; },
       lpush(key: string, value: string) { ops.push(() => self.lpush(key, value)); return this; },
+      ltrim(key: string, start: number, stop: number) { ops.push(() => self.ltrim(key, start, stop)); return this; },
       lrem(key: string, count: number, value: string) { ops.push(() => self.lrem(key, count, value)); return this; },
       hset(key: string, field: string, value: Primitive) { ops.push(() => self.hset(key, field, value)); return this; },
       async exec() { const results: any[] = []; for (const fn of ops) { results.push(await fn()); } return results; }

--- a/apps/backend/src/websocket/__tests__/retention.test.ts
+++ b/apps/backend/src/websocket/__tests__/retention.test.ts
@@ -1,0 +1,57 @@
+const retentionConfig = { ttlSeconds: 86400, maxItems: 200 };
+
+jest.mock('../../config', () => ({
+  config: {
+    redis: {
+      unreadRetention: retentionConfig,
+    },
+  },
+}));
+
+jest.mock('../../lib/redis', () => ({
+  redis: {
+    expire: jest.fn(),
+    ltrim: jest.fn(),
+  },
+}));
+
+const { redis } = require('../../lib/redis');
+const { applyUnreadRetention } = require('../retention');
+
+const expireMock = redis.expire as jest.Mock;
+const ltrimMock = redis.ltrim as jest.Mock;
+
+describe('applyUnreadRetention', () => {
+  beforeEach(() => {
+    expireMock.mockReset();
+    expireMock.mockResolvedValue(1);
+    ltrimMock.mockReset();
+    ltrimMock.mockResolvedValue('OK');
+    retentionConfig.ttlSeconds = 86400;
+    retentionConfig.maxItems = 200;
+  });
+
+  it('applies expire and ltrim with configured retention', async () => {
+    await applyUnreadRetention('chat:unread:1');
+
+    expect(redis.ltrim).toHaveBeenCalledWith('chat:unread:1', 0, 199);
+    expect(redis.expire).toHaveBeenCalledWith('chat:unread:1', 86400);
+  });
+
+  it('skips operations when retention values are disabled', async () => {
+    retentionConfig.ttlSeconds = 0;
+    retentionConfig.maxItems = 0;
+
+    await applyUnreadRetention('chat:unread:2');
+
+    expect(redis.ltrim).not.toHaveBeenCalled();
+    expect(redis.expire).not.toHaveBeenCalled();
+  });
+
+  it('permits overriding retention per call', async () => {
+    await applyUnreadRetention('chat:unread:3', { ttlSeconds: 120, maxItems: 10 });
+
+    expect(redis.ltrim).toHaveBeenCalledWith('chat:unread:3', 0, 9);
+    expect(redis.expire).toHaveBeenCalledWith('chat:unread:3', 120);
+  });
+});

--- a/apps/backend/src/websocket/retention.ts
+++ b/apps/backend/src/websocket/retention.ts
@@ -1,0 +1,26 @@
+import { config } from '../config';
+import { redis } from '../lib/redis';
+
+interface RetentionConfig {
+  ttlSeconds?: number;
+  maxItems?: number;
+}
+
+export async function applyUnreadRetention(
+  key: string,
+  retention: RetentionConfig = config.redis.unreadRetention
+) {
+  const operations: Array<Promise<unknown>> = [];
+
+  if (retention.maxItems && retention.maxItems > 0) {
+    operations.push((redis as any).ltrim(key, 0, retention.maxItems - 1));
+  }
+
+  if (retention.ttlSeconds && retention.ttlSeconds > 0) {
+    operations.push(redis.expire(key, retention.ttlSeconds));
+  }
+
+  if (operations.length > 0) {
+    await Promise.all(operations);
+  }
+}

--- a/apps/backend/src/websocket/server.ts
+++ b/apps/backend/src/websocket/server.ts
@@ -5,6 +5,7 @@ import { Pool } from 'pg';
 import { logger } from '../services/logger';
 import { config } from '../config';
 import { redis } from '../lib/redis';
+import { applyUnreadRetention } from './retention';
 
 interface User {
   id: string;
@@ -226,7 +227,9 @@ export class WebSocketServer {
               if (this.userSockets.has(String(uid))) {
                 this.io.to(`user:${uid}`).emit('new_message', message);
               } else {
-                await redis.lpush(`chat:unread:${uid}`, JSON.stringify(message));
+                const unreadKey = `chat:unread:${uid}`;
+                await redis.lpush(unreadKey, JSON.stringify(message));
+                await applyUnreadRetention(unreadKey);
               }
             }
 
@@ -266,7 +269,9 @@ export class WebSocketServer {
           if (this.userSockets.has(String(destinatarioId))) {
             this.io.to(`user:${destinatarioId}`).emit('new_message', message);
           } else {
-            await redis.lpush(`chat:unread:${destinatarioId}`, JSON.stringify(message));
+            const unreadKey = `chat:unread:${destinatarioId}`;
+            await redis.lpush(unreadKey, JSON.stringify(message));
+            await applyUnreadRetention(unreadKey);
           }
           // Confirmar ao remetente
           socket.emit('message_sent', message);
@@ -514,7 +519,9 @@ export class WebSocketServer {
       this.io.to(`user:${userId}`).emit('notification', notification);
     } else {
       // Armazenar para envio posterior
-      await redis.lpush(`unread:${userId}`, JSON.stringify(notification));
+      const unreadKey = `unread:${userId}`;
+      await redis.lpush(unreadKey, JSON.stringify(notification));
+      await applyUnreadRetention(unreadKey);
     }
   }
 


### PR DESCRIPTION
## Summary
- add configurable retention settings for unread chat messages and notifications stored in Redis
- trim or expire Redis unread lists after pushes and document new environment defaults
- extend the in-memory Redis stub and add Jest coverage to ensure TTL/trim logic is applied

## Testing
- `npm --prefix apps/backend test -- src/websocket/__tests__/retention.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68dac6dceee083248ac4ff3c9e27f08b