### PR TITLE
Refactor refresh token handling per device

### DIFF
--- a/apps/backend/src/__tests__/authRoutes.test.ts
+++ b/apps/backend/src/__tests__/authRoutes.test.ts
@@ -128,7 +128,8 @@ describe('Auth and protected routes', () => {
       expect(res.status).toBe(200);
       expect(authService.revokeRefreshToken).toHaveBeenCalledWith('encoded-token', {
         deviceId: null,
-        userAgent: null
+        userAgent: null,
+        ipAddress: expect.stringContaining('127.0.0.1')
       });
     });
 

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -104,9 +104,12 @@ export const AuthService = {
 
     return fallbackValidateRefreshToken(token);
   },
-  async refreshWithToken(refreshToken: string) {
+  async refreshWithToken(
+    refreshToken: string,
+    metadata?: Parameters<typeof authService.refreshWithToken>[1]
+  ) {
     if (!shouldUseFallback(authService.refreshWithToken)) {
-      return authService.refreshWithToken(refreshToken);
+      return authService.refreshWithToken(refreshToken, metadata ?? {});
     }
 
     const payload = await fallbackValidateRefreshToken(refreshToken);
@@ -123,9 +126,12 @@ export const AuthService = {
       }
     };
   },
-  async revokeRefreshToken(token: string): Promise<void> {
+  async revokeRefreshToken(
+    token: string,
+    metadata?: Parameters<typeof authService.revokeRefreshToken>[1]
+  ): Promise<void> {
     if (!shouldUseFallback(authService.revokeRefreshToken)) {
-      await authService.revokeRefreshToken(token);
+      await authService.revokeRefreshToken(token, metadata);
     }
   },
   async verifyToken(token: string): Promise<JWTPayload> {

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -239,7 +239,8 @@ const logoutHandler: RequestHandler<
   const refreshToken = extractRefreshToken(req);
   const deviceId = req.body?.deviceId ?? null;
   const userAgent = req.get('user-agent') || null;
-  const revocationMetadata = { deviceId, userAgent };
+  const ipAddress = req.ip || req.socket.remoteAddress || 'unknown';
+  const revocationMetadata = { deviceId, userAgent, ipAddress };
 
   if (refreshToken) {
     try {

--- a/apps/backend/src/services/__tests__/auth.service.test.ts
+++ b/apps/backend/src/services/__tests__/auth.service.test.ts
@@ -1,15 +1,22 @@
 import { createHash } from 'node:crypto';
+import bcrypt from 'bcryptjs';
 import { AuthService } from '../auth.service';
 import type { Pool } from 'pg';
 import type { RedisClient } from '../../lib/redis';
+import { env } from '../../config/env';
 
-type RefreshTokenRow = {
+interface RefreshTokenRow {
   userId: number;
+  tokenId: string;
+  tokenHash: string;
+  deviceId: string;
+  userAgent: string | null;
+  ipAddress: string | null;
   expiresAt: Date;
-  revoked: boolean;
-};
+  revokedAt: Date | null;
+}
 
-type UserRow = {
+interface UserRow {
   id: number;
   email: string;
   senha_hash: string;
@@ -20,34 +27,151 @@ type UserRow = {
   ultimo_login: Date | null;
   data_criacao: Date;
   data_atualizacao: Date;
-};
+}
 
 class PoolMock {
   public users = new Map<number, UserRow>();
-  public refreshTokens = new Map<string, RefreshTokenRow>();
+  public refreshTokensByHash = new Map<string, RefreshTokenRow>();
+  private refreshTokensByDevice = new Map<string, string>();
+
+  private normalize(sql: string): string {
+    return sql.trim().replace(/\s+/g, ' ').toLowerCase();
+  }
 
   async query(sql: string, params: any[] = []): Promise<{ rows: any[]; rowCount: number }> {
-    const trimmed = sql.trim().toLowerCase();
+    const normalized = this.normalize(sql);
 
-    if (trimmed.startsWith('create table if not exists refresh_tokens')) {
+    if (normalized.startsWith("select to_regclass('public.user_refresh_tokens')")) {
+      return { rows: [{ table_name: 'user_refresh_tokens' }], rowCount: 1 };
+    }
+
+    if (normalized.startsWith("select to_regclass('public.refresh_tokens')")) {
+      return { rows: [{ table_name: null }], rowCount: 1 };
+    }
+
+    if (normalized.startsWith('select token_hash, user_id, expires_at, revoked, revoked_at from refresh_tokens')) {
       return { rows: [], rowCount: 0 };
     }
 
-    if (trimmed.startsWith('create index if not exists')) {
-      return { rows: [], rowCount: 0 };
+    if (normalized.startsWith('insert into user_refresh_tokens')) {
+      if (normalized.includes('do nothing')) {
+        const [userId, tokenId, tokenHash, deviceId, expiresAt, revokedAt] = params as [
+          number,
+          string,
+          string,
+          string,
+          Date,
+          Date | null
+        ];
+        const deviceKey = `${userId}:${deviceId}`;
+        if (this.refreshTokensByDevice.has(deviceKey)) {
+          return { rows: [], rowCount: 0 };
+        }
+        const row: RefreshTokenRow = {
+          userId,
+          tokenId,
+          tokenHash,
+          deviceId,
+          userAgent: null,
+          ipAddress: null,
+          expiresAt: new Date(expiresAt),
+          revokedAt: revokedAt ? new Date(revokedAt) : null
+        };
+        this.refreshTokensByHash.set(tokenHash, row);
+        this.refreshTokensByDevice.set(deviceKey, tokenHash);
+        return { rows: [], rowCount: 1 };
+      }
+
+      const [userId, tokenId, tokenHash, deviceId, userAgent, ipAddress, expiresAt] = params as [
+        number,
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        Date
+      ];
+      const deviceKey = `${userId}:${deviceId}`;
+      const previousHash = this.refreshTokensByDevice.get(deviceKey);
+      if (previousHash && previousHash !== tokenHash) {
+        this.refreshTokensByHash.delete(previousHash);
+      }
+      const row: RefreshTokenRow = {
+        userId,
+        tokenId,
+        tokenHash,
+        deviceId,
+        userAgent: userAgent ?? null,
+        ipAddress: ipAddress ?? null,
+        expiresAt: new Date(expiresAt),
+        revokedAt: null
+      };
+      this.refreshTokensByHash.set(tokenHash, row);
+      this.refreshTokensByDevice.set(deviceKey, tokenHash);
+      return { rows: [], rowCount: 1 };
     }
 
-    if (trimmed.startsWith('select * from usuarios')) {
+    if (normalized.startsWith('select user_id, token_id, device_id, user_agent, ip_address, expires_at, revoked_at from user_refresh_tokens where token_hash = $1')) {
+      const tokenHash = params[0];
+      const entry = this.refreshTokensByHash.get(tokenHash);
+      if (!entry) {
+        return { rows: [], rowCount: 0 };
+      }
+      return {
+        rows: [{
+          user_id: entry.userId,
+          token_id: entry.tokenId,
+          token_hash: entry.tokenHash,
+          device_id: entry.deviceId,
+          user_agent: entry.userAgent,
+          ip_address: entry.ipAddress,
+          expires_at: entry.expiresAt,
+          revoked_at: entry.revokedAt
+        }],
+        rowCount: 1
+      };
+    }
+
+    if (normalized.startsWith('update user_refresh_tokens set revoked_at = now(), updated_at = now() where token_hash = $1')) {
+      const tokenHash = params[0];
+      const entry = this.refreshTokensByHash.get(tokenHash);
+      if (entry) {
+        entry.revokedAt = new Date();
+        this.refreshTokensByHash.set(tokenHash, entry);
+      }
+      return { rows: [], rowCount: entry ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('update user_refresh_tokens set revoked_at = now(), updated_at = now() where user_id = $1 and revoked_at is null')) {
+      const userId = params[0];
+      let count = 0;
+      for (const [hash, entry] of this.refreshTokensByHash.entries()) {
+        if (entry.userId === userId && entry.revokedAt === null) {
+          entry.revokedAt = new Date();
+          this.refreshTokensByHash.set(hash, entry);
+          count += 1;
+        }
+      }
+      return { rows: [], rowCount: count };
+    }
+
+    if (normalized.startsWith('select * from usuarios where email = $1 and ativo = true')) {
       const email = params[0];
       const user = Array.from(this.users.values()).find((u) => u.email === email && u.ativo);
       return { rows: user ? [user] : [], rowCount: user ? 1 : 0 };
     }
 
-    if (trimmed.startsWith('update usuarios set ultimo_login')) {
+    if (normalized.startsWith('select * from usuarios where id = $1 and ativo = true')) {
+      const id = params[0];
+      const user = this.users.get(id);
+      return { rows: user && user.ativo ? [user] : [], rowCount: user && user.ativo ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('update usuarios set ultimo_login')) {
       return { rows: [], rowCount: 1 };
     }
 
-    if (trimmed.startsWith('select id, email, papel as role, ativo from usuarios where id = $1')) {
+    if (normalized.startsWith('select id, email, papel as role, ativo from usuarios where id = $1')) {
       const user = this.users.get(params[0]);
       if (!user) {
         return { rows: [], rowCount: 0 };
@@ -58,44 +182,12 @@ class PoolMock {
       };
     }
 
-    if (trimmed.startsWith('select ativo from usuarios where id = $1')) {
+    if (normalized.startsWith('select ativo from usuarios where id = $1')) {
       const user = this.users.get(params[0]);
       if (!user) {
         return { rows: [], rowCount: 0 };
       }
       return { rows: [{ ativo: user.ativo }], rowCount: 1 };
-    }
-
-    if (trimmed.startsWith('insert into refresh_tokens')) {
-      const [tokenHash, userId, expiresAt] = params as [string, number, Date];
-      this.refreshTokens.set(tokenHash, {
-        userId,
-        expiresAt: new Date(expiresAt),
-        revoked: false
-      });
-      return { rows: [], rowCount: 1 };
-    }
-
-    if (trimmed.startsWith('select user_id, expires_at, revoked from refresh_tokens')) {
-      const tokenHash = params[0];
-      const entry = this.refreshTokens.get(tokenHash);
-      if (!entry) {
-        return { rows: [], rowCount: 0 };
-      }
-      return {
-        rows: [{ user_id: entry.userId, expires_at: entry.expiresAt, revoked: entry.revoked }],
-        rowCount: 1
-      };
-    }
-
-    if (trimmed.startsWith('update refresh_tokens set revoked = true')) {
-      const tokenHash = params[0];
-      const entry = this.refreshTokens.get(tokenHash);
-      if (entry) {
-        entry.revoked = true;
-        this.refreshTokens.set(tokenHash, entry);
-      }
-      return { rows: [], rowCount: entry ? 1 : 0 };
     }
 
     throw new Error(`Unhandled SQL in PoolMock: ${sql}`);
@@ -131,12 +223,14 @@ class RedisMock {
   }
 }
 
-describe('AuthService refresh tokens', () => {
+describe('AuthService refresh tokens with device metadata', () => {
+  const originalRedisHost = env.REDIS_HOST;
   let pool: PoolMock;
   let redis: RedisMock;
   let service: AuthService;
 
   beforeEach(() => {
+    env.REDIS_HOST = undefined;
     pool = new PoolMock();
     redis = new RedisMock();
     service = new AuthService(pool as unknown as Pool, redis as unknown as RedisClient);
@@ -145,7 +239,7 @@ describe('AuthService refresh tokens', () => {
     pool.users.set(1, {
       id: 1,
       email: 'user@example.com',
-      senha_hash: 'hash',
+      senha_hash: bcrypt.hashSync('secret', 8),
       nome: 'Usuário Teste',
       papel: 'admin',
       ativo: true,
@@ -156,51 +250,103 @@ describe('AuthService refresh tokens', () => {
     });
   });
 
-  it('rotates refresh tokens on successful renewal', async () => {
-    const payload = { id: 1, email: 'user@example.com', role: 'admin' };
-    const originalRefresh = await service.generateRefreshToken(payload);
-    const originalHash = createHash('sha256').update(originalRefresh).digest('hex');
-
-    const result = await service.refreshWithToken(originalRefresh);
-
-    expect(result.token).toBeDefined();
-    expect(result.refreshToken).toBeDefined();
-    expect(result.refreshToken).not.toEqual(originalRefresh);
-
-    const storedOriginal = pool.refreshTokens.get(originalHash);
-    expect(storedOriginal?.revoked).toBe(true);
-
-    const newHash = createHash('sha256').update(result.refreshToken).digest('hex');
-    const storedNew = pool.refreshTokens.get(newHash);
-    expect(storedNew).toBeDefined();
-    expect(storedNew?.revoked).toBe(false);
+  afterEach(() => {
+    env.REDIS_HOST = originalRedisHost;
   });
 
-  it('rejects expired refresh tokens', async () => {
-    const payload = { id: 1, email: 'user@example.com', role: 'admin' };
-    const refreshToken = await service.generateRefreshToken(payload);
-    const tokenHash = createHash('sha256').update(refreshToken).digest('hex');
+  it('persists device metadata and rotates refresh tokens por dispositivo', async () => {
+    const loginA = await service.login('user@example.com', 'secret', '10.0.0.1', 'device-a', 'UA-A');
+    const loginB = await service.login('user@example.com', 'secret', '10.0.0.2', 'device-b', 'UA-B');
 
-    const entry = pool.refreshTokens.get(tokenHash);
-    if (!entry) {
+    expect(loginA).not.toBeNull();
+    expect(loginB).not.toBeNull();
+
+    const refreshA = loginA?.refreshToken;
+    const refreshB = loginB?.refreshToken;
+
+    expect(refreshA).toBeDefined();
+    expect(refreshB).toBeDefined();
+
+    const hashA = createHash('sha256').update(refreshA!).digest('hex');
+    const hashB = createHash('sha256').update(refreshB!).digest('hex');
+
+    expect(pool.refreshTokensByHash.get(hashA)).toMatchObject({
+      deviceId: 'device-a',
+      userAgent: 'UA-A',
+      ipAddress: '10.0.0.1',
+      revokedAt: null
+    });
+    expect(pool.refreshTokensByHash.get(hashB)).toMatchObject({
+      deviceId: 'device-b',
+      userAgent: 'UA-B',
+      ipAddress: '10.0.0.2',
+      revokedAt: null
+    });
+
+    const rotated = await service.renewAccessToken(refreshA!, {
+      deviceId: 'device-a',
+      userAgent: 'UA-A',
+      ipAddress: '10.0.0.3'
+    });
+
+    expect(rotated.refreshToken).toBeDefined();
+    expect(rotated.refreshToken).not.toEqual(refreshA);
+
+    const newHashA = createHash('sha256').update(rotated.refreshToken!).digest('hex');
+    expect(pool.refreshTokensByHash.has(hashA)).toBe(false);
+    expect(pool.refreshTokensByHash.get(newHashA)).toMatchObject({
+      deviceId: 'device-a',
+      userAgent: 'UA-A',
+      ipAddress: '10.0.0.3',
+      revokedAt: null
+    });
+
+    expect(pool.refreshTokensByHash.get(hashB)?.revokedAt).toBeNull();
+
+    await service.revokeRefreshToken(refreshB!, {
+      deviceId: 'device-b',
+      userAgent: 'UA-B',
+      ipAddress: '10.0.0.2'
+    });
+
+    expect(pool.refreshTokensByHash.get(hashB)?.revokedAt).toBeInstanceOf(Date);
+
+    await expect(
+      service.renewAccessToken(refreshB!, {
+        deviceId: 'device-b',
+        userAgent: 'UA-B',
+        ipAddress: '10.0.0.2'
+      })
+    ).rejects.toThrow('Refresh token inválido');
+  });
+
+  it('rejects expired refresh tokens and marca como revogado', async () => {
+    const payload = { id: 1, email: 'user@example.com', role: 'admin' as const };
+    const refreshToken = await service.generateRefreshToken(payload, {
+      deviceId: 'device-expired',
+      userAgent: 'UA-Expired',
+      ipAddress: '10.0.0.4'
+    });
+
+    const hash = createHash('sha256').update(refreshToken).digest('hex');
+    const stored = pool.refreshTokensByHash.get(hash);
+    if (!stored) {
       throw new Error('Refresh token não foi persistido no mock');
     }
-    // Expira no passado no "banco"
-    entry.expiresAt = new Date(Date.now() - 1000);
-    pool.refreshTokens.set(tokenHash, entry);
 
-    // E também no cache Redis (quando habilitado via env)
-    // chave: auth:refresh:<hash>
-    // valor: { userId, expiresAt: ISOString }
-    // @ts-ignore acessando mock diretamente
-    await (redis as any).set(
-      `auth:refresh:${tokenHash}`,
-      JSON.stringify({ userId: entry.userId, expiresAt: entry.expiresAt.toISOString() })
-    );
+    stored.expiresAt = new Date(Date.now() - 1000);
+    pool.refreshTokensByHash.set(hash, stored);
 
-    await expect(service.refreshWithToken(refreshToken)).rejects.toThrow('Refresh token expirado');
+    expect(pool.refreshTokensByHash.get(hash)?.expiresAt.getTime()).toBeLessThan(Date.now());
 
-    const revokedEntry = pool.refreshTokens.get(tokenHash);
-    expect(revokedEntry?.revoked).toBe(true);
+    await expect(
+      service.refreshWithToken(refreshToken, {
+        deviceId: 'device-expired',
+        userAgent: 'UA-Expired',
+        ipAddress: '10.0.0.4'
+      })
+    ).rejects.toThrow('Refresh token expirado');
+
+    expect(pool.refreshTokensByHash.get(hash)?.revokedAt).toBeInstanceOf(Date);
   });
 });


### PR DESCRIPTION
## Summary
- refactor the auth service to persist refresh tokens in `user_refresh_tokens`, migrate legacy rows, and track device/ip metadata per token
- pass device, user-agent, and IP data through the auth routes and middleware so revocations target the correct device
- extend auth-related Jest tests to cover multi-device login/refresh/logout flows and update expectations for logout metadata

## Testing
- npm run test:backend

------
https://chatgpt.com/codex/tasks/task_e_68dac6d84b0c8324b016cae1744c512f