### PR TITLE
Fix OpenAPI registry initialization for Zod schemas

### DIFF
--- a/apps/backend/src/openapi/routes.ts
+++ b/apps/backend/src/openapi/routes.ts
@@ -1,5 +1,7 @@
-import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { OpenAPIRegistry, extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
+
+extendZodWithOpenApi(z);
 
 const registry = new OpenAPIRegistry();
 


### PR DESCRIPTION
## Summary
- extend Zod with the OpenAPI helpers before registering schemas to fix runtime errors when generating docs

## Testing
- npm run build --if-present

------
https://chatgpt.com/codex/tasks/task_e_68deb508dfa48324a2788ddeb225edbb