### PR TITLE
Fix OpenAPI schema registration to avoid zod-to-openapi crash

### DIFF
--- a/apps/backend/src/openapi/routes.ts
+++ b/apps/backend/src/openapi/routes.ts
@@ -4,18 +4,22 @@ import { z } from 'zod';
 const registry = new OpenAPIRegistry();
 
 // Auth Schemas
-const loginSchema = registry.register('Login', z.object({
+const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6)
-}));
+});
 
-const tokenSchema = registry.register('Token', z.object({
+registry.register('Login', loginSchema);
+
+const tokenSchema = z.object({
   accessToken: z.string(),
   refreshToken: z.string()
-}));
+});
+
+registry.register('Token', tokenSchema);
 
 // Beneficiária Schemas
-const beneficiariaSchema = registry.register('Beneficiaria', z.object({
+const beneficiariaSchema = z.object({
   id: z.string().uuid(),
   nome: z.string(),
   cpf: z.string(),
@@ -26,10 +30,12 @@ const beneficiariaSchema = registry.register('Beneficiaria', z.object({
   status: z.enum(['ATIVA', 'INATIVA', 'AGUARDANDO']),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime()
-}));
+});
+
+registry.register('Beneficiaria', beneficiariaSchema);
 
 // Projeto Schemas
-const projetoSchema = registry.register('Projeto', z.object({
+const projetoSchema = z.object({
   id: z.string().uuid(),
   nome: z.string(),
   descricao: z.string(),
@@ -38,7 +44,9 @@ const projetoSchema = registry.register('Projeto', z.object({
   status: z.enum(['ATIVO', 'INATIVO', 'CONCLUIDO']),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime()
-}));
+});
+
+registry.register('Projeto', projetoSchema);
 
 // Auth Routes
 registry.registerPath({


### PR DESCRIPTION
## Summary
- define Zod schemas before registration with the OpenAPI registry
- register login, token, beneficiária, and projeto schemas separately to avoid runtime errors

## Testing
- npm run dev *(fails: COOKIE_SECRET env var missing in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deb9e3e59883248f6e5a1d37e546ce