### PR TITLE
fix: ensure backend uses OpenAPI-extended zod instance

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import type { SignOptions } from 'jsonwebtoken';
 
 type MsStringValue = import('ms').StringValue;

--- a/apps/backend/src/controllers/planoAcaoController.ts
+++ b/apps/backend/src/controllers/planoAcaoController.ts
@@ -4,7 +4,7 @@ import { logger } from '../services/logger';
 import { PlanoAcao, PlanoAcaoResponse } from '../models/PlanoAcao';
 import { formatDateToISO } from '../utils/dateFormatter';
 import { validatePlanoAcao } from '../validators/planoAcao.validator';
-import { ZodError } from 'zod';
+import { ZodError } from '../openapi/init';
 
 const hydratePlano = (row: any): PlanoAcao => {
   const itens = Array.isArray(row.itens) ? row.itens : [];

--- a/apps/backend/src/middleware/authMiddleware.ts
+++ b/apps/backend/src/middleware/authMiddleware.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { logger } from '../services/logger';
 
 if (process.env.NODE_ENV === 'production' && !process.env.JWT_SECRET) {

--- a/apps/backend/src/middleware/validateRequest.ts
+++ b/apps/backend/src/middleware/validateRequest.ts
@@ -1,5 +1,5 @@
 import { Request as ExpressRequest, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 interface CustomRequest extends ExpressRequest {
   body: any;

--- a/apps/backend/src/middleware/validateSchema.ts
+++ b/apps/backend/src/middleware/validateSchema.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { ValidationError } from '../utils';
 
 export const validateSchema = (schema: z.ZodTypeAny) => {

--- a/apps/backend/src/middleware/validationMiddleware.ts
+++ b/apps/backend/src/middleware/validationMiddleware.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
-import { z, type ZodIssue } from 'zod';
+import { z, type ZodIssue } from '../openapi/init';
 import { logger } from '../services/logger';
 
 type RequestShape = {

--- a/apps/backend/src/openapi/init.ts
+++ b/apps/backend/src/openapi/init.ts
@@ -1,7 +1,10 @@
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
-import { z } from 'zod';
+import { z as baseZ, ZodError } from 'zod';
+import type { ZodIssue } from 'zod';
 
 // Estende o Zod com o plugin OpenAPI
-extendZodWithOpenApi(z);
+extendZodWithOpenApi(baseZ);
 
-export { z };
+export const z = baseZ;
+export { ZodError };
+export type { ZodIssue };

--- a/apps/backend/src/routes/beneficiarias.routes.ts
+++ b/apps/backend/src/routes/beneficiarias.routes.ts
@@ -17,7 +17,7 @@ import {
   validateBeneficiaria
 } from '../validators/beneficiaria.validator';
 import { pool } from '../config/database';
-import { ZodError } from 'zod';
+import { ZodError } from '../openapi/init';
 import { redis } from '../lib/redis';
 import { uploadSingle, UPLOAD_DIR } from '../middleware/upload';
 import type { BeneficiariaDetalhada } from '../types/beneficiarias';

--- a/apps/backend/src/routes/feed.routes.ts
+++ b/apps/backend/src/routes/feed.routes.ts
@@ -8,7 +8,7 @@ import { pool } from '../config/database';
 import { loggerService } from '../services/logger';
 import { catchAsync } from '../middleware/errorHandler';
 import { validateRequest } from '../middleware/validationMiddleware';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 const router = Router();
 

--- a/apps/backend/src/routes/formularios.routes.ts
+++ b/apps/backend/src/routes/formularios.routes.ts
@@ -3,7 +3,7 @@ import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { pool } from '../config/database';
 import { successResponse, errorResponse } from '../utils/responseFormatter';
 import { validateRequest } from '../middleware/validationMiddleware';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { renderFormPdf, renderAnamnesePdf, renderFichaEvolucaoPdf, renderTermosPdf, renderVisaoHolisticaPdf } from '../services/formsExport.service';
 
 type TermoConsentimentoRow = {

--- a/apps/backend/src/routes/notifications.routes.ts
+++ b/apps/backend/src/routes/notifications.routes.ts
@@ -3,7 +3,7 @@ import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { pool } from '../config/database';
 import { successResponse, errorResponse } from '../utils/responseFormatter';
 import { validateRequest } from '../middleware/validationMiddleware';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { loggerService } from '../services/logger';
 
 const router = Router();

--- a/apps/backend/src/routes/organizacoes.routes.ts
+++ b/apps/backend/src/routes/organizacoes.routes.ts
@@ -3,7 +3,7 @@ import { pool } from '../config/database';
 import { authenticateToken, authorize, AuthenticatedRequest } from '../middleware/auth';
 import { successResponse, errorResponse } from '../utils/responseFormatter';
 import { validateRequest } from '../middleware/validationMiddleware';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 const router = Router();
 

--- a/apps/backend/src/routes/planoAcao.routes.ts
+++ b/apps/backend/src/routes/planoAcao.routes.ts
@@ -3,7 +3,7 @@ import { authenticateToken, authorize } from '../middleware/auth';
 import { validateRequest } from '../middleware/validationMiddleware';
 import { planoAcaoController } from '../controllers/planoAcaoController';
 import { planoAcaoSchema } from '../validators/planoAcao.validator';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 const router = Router();
 

--- a/apps/backend/src/services/feed.service.ts
+++ b/apps/backend/src/services/feed.service.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 import type { RedisClient } from '../lib/redis';
 import { loggerService } from '../services/logger';
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { feedPostSchema, feedCommentSchema } from '../validators/feed.validator';
 import { formatArrayDates, formatObjectDates } from '../utils/dateFormatter';
 import { cacheService } from './cache.service';

--- a/apps/backend/src/validators/auth.validator.ts
+++ b/apps/backend/src/validators/auth.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 const emptyObject = z.object({}).optional();
 

--- a/apps/backend/src/validators/beneficiaria.validator.ts
+++ b/apps/backend/src/validators/beneficiaria.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 import { isCPF } from 'brazilian-values';
 
 const dateRegex = /^\d{4}-\d{2}-\d{2}$/;

--- a/apps/backend/src/validators/feed.validator.ts
+++ b/apps/backend/src/validators/feed.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 // Schema para posts do feed
 export const feedPostSchema = z.object({

--- a/apps/backend/src/validators/oficina.validator.ts
+++ b/apps/backend/src/validators/oficina.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 // Schema para horários (formato HH:mm)
 const horarioSchema = z.string().regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, 'Formato inválido. Use HH:mm');

--- a/apps/backend/src/validators/participacao.validator.ts
+++ b/apps/backend/src/validators/participacao.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 // Schema para participação
 export const participacaoSchema = z.object({

--- a/apps/backend/src/validators/planoAcao.validator.ts
+++ b/apps/backend/src/validators/planoAcao.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/apps/backend/src/validators/projeto.validator.ts
+++ b/apps/backend/src/validators/projeto.validator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from '../openapi/init';
 
 // Schema base para projeto
 export const projetoSchema = z.object({


### PR DESCRIPTION
## Summary
- centralize the OpenAPI extension in a single z instance and re-export shared helpers
- update backend routes, middleware, services, and validators to consume the shared z import

## Testing
- npm run dev *(fails: Redis and PostgreSQL refused connection in dev container)*

------
https://chatgpt.com/codex/tasks/task_e_68debd97f7408324b8e46e7b8d8b0ee7