### PR TITLE
Fix delete method to validate affected rows in base repository

### DIFF
--- a/apps/backend/src/repositories/__tests__/BeneficiariaRepository.test.ts
+++ b/apps/backend/src/repositories/__tests__/BeneficiariaRepository.test.ts
@@ -120,7 +120,9 @@ describe('BeneficiariaRepository', () => {
   describe('delete', () => {
     it('deve deletar beneficiária existente', async () => {
       const created = await factory.create('beneficiaria');
-      await repository.delete(created.id);
+      const result = await repository.delete(created.id);
+
+      expect(result).toBe(true);
 
       const exists = await dbAssertions.recordExists('beneficiarias', {
         id: created.id

--- a/apps/backend/src/repositories/base.repository.ts
+++ b/apps/backend/src/repositories/base.repository.ts
@@ -1,5 +1,6 @@
-import { pool, query, transaction } from '../config/database';
+import { pool, query, transaction, executeQuery } from '../config/database';
 import { logger } from '../services/logger';
+import { NotFoundError } from '../utils/errors';
 
 export interface BaseEntity {
   id: number;
@@ -167,8 +168,14 @@ export class BaseRepository<T extends BaseEntity> {
     }
 
     try {
-      const result = await query(sql, [id]);
-      return result.length > 0;
+      const result = await executeQuery(sql, [id]);
+      const affectedRows = result.rowCount ?? 0;
+
+      if (affectedRows === 0) {
+        throw new NotFoundError(`Registro com ID ${id} não encontrado em ${this.tableName}`);
+      }
+
+      return affectedRows > 0;
     } catch (error) {
       logger.error(`Erro ao deletar registro em ${this.tableName}:`, error);
       throw error;


### PR DESCRIPTION
## Summary
- update the base repository delete implementation to use executeQuery so the affected row count is available
- throw a NotFoundError when no records are removed and return true when a deletion occurs
- adjust the BeneficiariaRepository test to assert the delete call resolves to true for existing records

## Testing
- npm test --prefix apps/backend -- BeneficiariaRepository *(fails: jest binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc3ceff28832483099279318295e2