### PR TITLE
Ensure matriculas pagination total is numeric

### DIFF
--- a/apps/backend/src/services/__tests__/matriculas.service.test.ts
+++ b/apps/backend/src/services/__tests__/matriculas.service.test.ts
@@ -131,11 +131,11 @@ describe('MatriculasService', () => {
       statusMatricula: undefined
     };
 
-    it('utiliza a contagem total retornada pelo banco', async () => {
+    it('utiliza a contagem total retornada pelo banco mesmo quando enviada como string', async () => {
       pool.query.mockResolvedValueOnce({
         rows: [
-          { id: 1, total_count: 12 },
-          { id: 2, total_count: 12 }
+          { id: 1, total_count: '12' },
+          { id: 2, total_count: '12' }
         ]
       });
 
@@ -149,6 +149,7 @@ describe('MatriculasService', () => {
         total: 12,
         totalPages: 3
       });
+      expect(typeof result.pagination.total).toBe('number');
       expect(result.data).toEqual([
         expect.objectContaining({ id: 1 }),
         expect.objectContaining({ id: 2 })

--- a/apps/backend/src/services/matriculas.service.ts
+++ b/apps/backend/src/services/matriculas.service.ts
@@ -141,7 +141,12 @@ export class MatriculasService {
     const result = await this.pool.query(query, params);
     await this.cacheService.deletePattern('cache:matriculas:*');
 
-    const total = result.rows[0]?.total_count ?? 0;
+    const totalCountValue = result.rows[0]?.total_count;
+    const parsedTotal =
+      totalCountValue !== undefined && totalCountValue !== null
+        ? Number(totalCountValue)
+        : 0;
+    const total = Number.isNaN(parsedTotal) ? 0 : parsedTotal;
     const data = result.rows.map(({ total_count, ...row }) => row);
     const totalPages = total > 0 ? Math.ceil(total / limit) : 0;
 


### PR DESCRIPTION
## Summary
- ensure listarMatriculas coerces the total_count column into a numeric total before building pagination metadata
- keep totalPages calculation aligned with the numeric total and existing pagination contract
- extend matriculas service unit test to cover numeric conversion when total_count arrives as a string

## Testing
- TS_JEST_TRANSPILE_ONLY=true npx jest src/services/__tests__/matriculas.service.test.ts *(fails: src/config/env.ts:116:19 - error TS2503: Cannot find namespace 'z')*

------
https://chatgpt.com/codex/tasks/task_e_68dfd9e35b208324950efa4fcef5e406