### PR TITLE
docs: add advanced failure analysis report

### DIFF
--- a/docs/reports/relatorio-analise-avancada-falhas.md
+++ b/docs/reports/relatorio-analise-avancada-falhas.md
@@ -1,0 +1,299 @@
+# Relatório de Análise Avançada de Falhas
+## Repositório: assist-move-assist
+
+**Data:** 03 de outubro de 2025  
+**Autor:** Manus AI  
+**Repositório:** brunonatanaelsr/assist-move-assist
+
+---
+
+## 1. Sumário Executivo
+
+Este relatório apresenta uma análise aprofundada do repositório **assist-move-assist**, um sistema de gestão para institutos sociais desenvolvido com React 18, Node.js/Express e PostgreSQL. A análise revelou um projeto com uma base arquitetural sólida, excelente documentação e uma estrutura de monorepo bem organizada. No entanto, foram identificados **riscos críticos de segurança e manutenção** que comprometem a estabilidade, a segurança e a manutenibilidade do sistema.
+
+Os problemas mais graves incluem a presença de **94 erros de compilação TypeScript** no backend, que impedem a execução de testes automatizados, e o uso de múltiplas dependências com vulnerabilidades conhecidas e sem suporte. A atividade recente no repositório, com um alto volume de *pull requests* focados em correções emergenciais, sugere que a equipe de desenvolvimento já está enfrentando as consequências dessa instabilidade técnica.
+
+Recomenda-se um **plano de ação imediato** para estabilizar o ambiente, corrigir os erros de compilação, atualizar as dependências críticas e fortalecer as práticas de qualidade de código antes de prosseguir com o desenvolvimento de novas funcionalidades.
+
+---
+
+## 2. Visão Geral da Análise
+
+A análise foi conduzida em múltiplas dimensões, incluindo estrutura do código, gestão de dependências, qualidade de código, testes automatizados e atividade do repositório. A tabela abaixo resume os principais pontos positivos e negativos identificados.
+
+| Categoria | Pontos Positivos | Pontos Negativos e Riscos |
+|:----------|:----------------|:--------------------------|
+| **Estrutura e Documentação** | Monorepo bem estruturado, documentação abrangente (README, guias de deploy), scripts de automação para desenvolvimento e CI | Nenhuma issue aberta, dificultando o rastreamento de problemas conhecidos |
+| **Gestão de Dependências** | Uso de `npm workspaces` para gerenciar o monorepo | **Vulnerabilidades críticas** (xlsx, multer), múltiplos pacotes deprecados e sem suporte (xss-clean, @hapi/joi), conflitos de versão (zod) |
+| **Qualidade do Código** | Código TypeScript moderno no frontend e backend, uso de cookies HttpOnly para segurança | **94 erros de compilação no backend**, inconsistências na importação de módulos (Zod), ausência de script de `lint` no backend |
+| **Testes Automatizados** | Cobertura de testes sólida no frontend (Vitest), estrutura para testes unitários, de integração e E2E (Jest, Playwright) | **Testes do backend não executam** devido a erros de compilação, ausência de dependências de teste (`supertest`) |
+| **Atividade do Repositório** | Desenvolvimento ativo com contribuições frequentes (288 PRs) | Alto volume de *pull requests* com foco em correções, indicando instabilidade e desenvolvimento reativo |
+
+---
+
+## 3. Análise Detalhada de Problemas
+
+### 3.1. Gestão de Dependências e Segurança (Risco Alto)
+
+A análise de dependências revelou problemas críticos que expõem a aplicação a riscos de segurança e instabilidade. A ferramenta `npm audit` reportou **4 vulnerabilidades**, sendo uma de severidade **alta** no pacote `xlsx` para a qual não existe correção disponível, e três moderadas relacionadas ao `esbuild` e `vite`.
+
+#### Vulnerabilidades Identificadas
+
+| Pacote | Severidade | Problema | Correção Disponível |
+|:-------|:-----------|:---------|:-------------------|
+| **xlsx** | Alta | Prototype Pollution (GHSA-4r6h-8v6p-xvw6) e ReDoS (GHSA-5pgg-2g8v-p4x9) | ❌ Não |
+| **multer** | Moderada | Versão 1.x possui múltiplas vulnerabilidades conhecidas | ✅ Sim (upgrade para 2.x) |
+| **esbuild** | Moderada | Permite requisições não autorizadas ao servidor de desenvolvimento | ✅ Sim (via upgrade do vite) |
+
+#### Pacotes Deprecados
+
+A instalação de dependências gerou múltiplos avisos sobre pacotes deprecados que não recebem mais suporte ou manutenção. Entre os mais críticos estão:
+
+- **xss-clean@0.1.4**: Pacote não mais suportado, usado para sanitização de entrada
+- **@hapi/joi@17.1.1**: Deve migrar para a versão standalone `joi`
+- **inflight@1.0.6**: Não suportado e causa vazamento de memória
+- **rimraf@2.7.1**: Versões anteriores a v4 não são mais suportadas
+- **glob@7.2.3**: Múltiplas instâncias de versões antigas (< v9)
+- **multer@1.4.5-lts.2**: Versão 1.x impactada por vulnerabilidades
+
+#### Conflitos de Versão
+
+Foi identificado um conflito significativo na versão do **Zod** entre frontend e backend:
+
+- **Backend**: zod@4.1.11
+- **Frontend**: zod@3.25.76
+
+Esta incompatibilidade de versão *major* pode causar problemas de integração, especialmente se houver compartilhamento de schemas de validação entre as camadas.
+
+### 3.2. Qualidade de Código e Erros de Compilação (Risco Alto)
+
+O código-fonte do backend apresenta **94 erros de compilação TypeScript**, o que impede a verificação de tipos e a execução de testes, tornando o desenvolvimento propenso a erros. A análise identificou os seguintes padrões de problemas:
+
+#### Erros de Namespace Zod (TS2503)
+
+O principal problema identificado é a inconsistência na importação do Zod. O projeto estende o Zod com o plugin OpenAPI em `src/openapi/init.ts`:
+
+```typescript
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z as baseZ, ZodError } from 'zod';
+
+extendZodWithOpenApi(baseZ);
+export const z = baseZ;
+```
+
+No entanto, múltiplos arquivos continuam importando a instância base diretamente de `zod`, causando o erro `Cannot find namespace 'z'`. Este problema afeta arquivos críticos como:
+
+- `src/config/env.ts`
+- `src/validators/auth.validator.ts`
+- Múltiplos arquivos de teste
+
+#### Falta de Declarações de Tipo
+
+Vários módulos não possuem as declarações de tipo TypeScript (`@types`) instaladas:
+
+- **@types/ws**: Necessário para o módulo `ws` usado no WebSocket
+- **@types/pdfkit**: Necessário para geração de PDFs
+- **@types/supertest**: Necessário para testes de integração HTTP
+
+Isso resulta em erros `TS7016: Could not find a declaration file for module`.
+
+#### Erros de Index Signature (TS7053)
+
+Múltiplos *services* apresentam erros ao tentar acessar propriedades de objetos dinamicamente:
+
+```typescript
+// Padrão problemático encontrado em:
+// - beneficiaria.service.ts
+// - oficina.service.ts
+// - participacao.service.ts
+// - projeto.service.ts
+
+validatedData[entry.field] // TS7053: Element implicitly has 'any' type
+```
+
+Este padrão ocorre quando o TypeScript não consegue inferir que a chave dinâmica é válida para o tipo do objeto.
+
+#### Problemas no WebSocket Service
+
+O arquivo `src/services/websocket.ts` apresenta múltiplos problemas:
+
+- Importa tipo `TokenPayload` que não existe em `auth.service`
+- Deveria usar `JWTPayload` de `types/auth.ts`
+- Propriedades WebSocket não reconhecidas (close, on, send, terminate, ping, readyState)
+
+#### Ausência de Script Lint no Backend
+
+Embora o backend possua um arquivo de configuração `eslint.config.mjs`, não há um script `lint` definido no `package.json`. Isso dificulta a detecção precoce de problemas de qualidade de código e inconsistências de estilo.
+
+### 3.3. Configuração e Execução de Testes (Risco Médio)
+
+A impossibilidade de executar a suíte de testes do backend representa uma falha grave no processo de garantia de qualidade. Embora a estrutura de testes esteja bem definida, ela é inutilizada pelos erros de compilação.
+
+#### Status dos Testes
+
+| Ambiente | Framework | Status | Observações |
+|:---------|:----------|:-------|:------------|
+| **Frontend** | Vitest | ✅ Passando | 10+ suítes de teste executando com sucesso |
+| **Backend** | Jest | ❌ Falhando | 94 erros de compilação impedem execução |
+| **E2E** | Playwright | ⚠️ Não verificado | Requer backend funcional |
+
+#### Testes Frontend (Vitest)
+
+Os testes do frontend estão funcionando corretamente, com múltiplas suítes passando:
+
+- Testes de serviços de autenticação: 10 testes
+- Testes de hooks: useBeneficiariaForm, useConfiguracoesUsuarios, useDashboard, etc.
+- Testes de componentes: MessagingWidget
+- Testes de rotas: rotas restritas e proteção de acesso
+
+Foram observados apenas avisos sobre *Future Flags* do React Router v7, que não são críticos.
+
+#### Testes Backend (Jest)
+
+A execução de `npm test` no backend falha completamente devido aos 94 erros de compilação TypeScript. Adicionalmente, foi identificada a ausência da dependência `supertest`, essencial para testes de integração HTTP.
+
+#### Dependências de Teste Faltantes
+
+- `supertest`: Biblioteca para testar APIs HTTP
+- `@types/supertest`: Declarações de tipo para supertest
+
+### 3.4. Análise de Commits e Pull Requests
+
+O repositório apresenta um padrão de desenvolvimento altamente ativo, mas com sinais de instabilidade:
+
+#### Estatísticas
+
+- **Total de Pull Requests**: 288
+- **Commits recentes**: Múltiplos commits com mensagens "ok", indicando desenvolvimento apressado
+- **Foco dos PRs recentes**: Correções de OpenAPI/Zod, validações, schemas
+
+#### Padrões Identificados
+
+Os últimos commits mostram um ciclo de correções emergenciais:
+
+- "fix: compute matricula totals with separate count"
+- "Update base repository delete result handling"
+- "Fix matriculas pagination totals"
+- "fix(backend): share OpenAPI-extended zod instance"
+- "fix(backend): align zod with openapi plugin"
+
+Este padrão sugere:
+
+- **Alto volume de fixes**: Indica problemas de qualidade de código
+- **Foco em OpenAPI/Zod**: Problema recorrente de integração
+- **Desenvolvimento reativo**: Correções após problemas em produção
+- **Merges frequentes**: Possível falta de revisão adequada
+
+---
+
+## 4. Pontos Positivos Identificados
+
+Apesar dos problemas críticos, o projeto apresenta diversos aspectos positivos que demonstram uma base sólida:
+
+### 4.1. Infraestrutura e Arquitetura
+
+- Monorepo bem estruturado com `npm workspaces`
+- Docker Compose para desenvolvimento local
+- Scripts de automação (deploy, e2e, codespaces)
+- Husky + lint-staged configurados para hooks Git
+- Suporte a múltiplos ambientes (desenvolvimento, staging, produção)
+
+### 4.2. Documentação
+
+- README detalhado com guias de instalação e execução
+- Documentação de credenciais de teste
+- Guias específicos de deploy e desenvolvimento
+- Estrutura de pastas bem documentada
+
+### 4.3. Stack Tecnológica Moderna
+
+**Frontend:**
+- React 18 + Vite
+- TypeScript
+- Tailwind CSS + shadcn/ui
+- React Query (TanStack)
+- Socket.io client
+
+**Backend:**
+- Node.js + Express
+- TypeScript
+- PostgreSQL (driver puro `pg`)
+- Redis (ioredis) para cache e controle de permissões
+- Socket.io para comunicação em tempo real
+- JWT + cookies HttpOnly (abordagem segura)
+
+### 4.4. Estrutura de Testes
+
+- Configuração completa de Vitest, Jest e Playwright
+- Testes unitários, de integração e E2E estruturados
+- Cobertura de testes no frontend funcionando
+
+### 4.5. Migrações e Banco de Dados
+
+- Migrações SQL versionadas (30+ arquivos de migração)
+- Scripts automatizados para aplicação de migrações
+- Estrutura clara de evolução do schema
+
+---
+
+## 5. Plano de Ação Recomendado
+
+Recomenda-se a seguinte sequência de ações para estabilizar o projeto e eliminar os riscos identificados:
+
+### Fase 1: Estabilização Crítica (Prioridade Máxima)
+
+| Passo | Ação | Objetivo | Tempo Estimado |
+|:------|:-----|:---------|:--------------|
+| 1 | **Padronizar importações Zod** | Refatorar todos os arquivos para importar `z` de `src/openapi/init.ts` | 2-4 horas |
+| 2 | **Instalar @types faltantes** | Adicionar `@types/ws`, `@types/pdfkit`, `@types/supertest` | 15 minutos |
+| 3 | **Corrigir erros de index signature** | Implementar *type guards* ou *assertions* nos services afetados | 3-5 horas |
+| 4 | **Corrigir WebSocket service** | Ajustar importações de tipos e propriedades | 1 hora |
+| 5 | **Validar compilação** | Garantir que `npx tsc --noEmit` execute sem erros | 30 minutos |
+| 6 | **Validar testes backend** | Garantir que `npm test` execute sem erros | 1 hora |
+
+### Fase 2: Segurança e Dependências (Prioridade Alta)
+
+| Passo | Ação | Objetivo | Tempo Estimado |
+|:------|:-----|:---------|:--------------|
+| 7 | **Atualizar multer** | Migrar para versão 2.x | 2-3 horas |
+| 8 | **Substituir xss-clean** | Implementar sanitização com biblioteca moderna | 2-3 horas |
+| 9 | **Avaliar alternativas para xlsx** | Pesquisar e testar bibliotecas alternativas ou mitigações | 4-6 horas |
+| 10 | **Migrar @hapi/joi** | Atualizar para versão standalone `joi` | 1-2 horas |
+| 11 | **Atualizar pacotes deprecados** | Atualizar glob, rimraf, inflight | 2-3 horas |
+| 12 | **Alinhar versões Zod** | Sincronizar versão entre frontend e backend | 1-2 horas |
+
+### Fase 3: Qualidade e Processos (Prioridade Média)
+
+| Passo | Ação | Objetivo | Tempo Estimado |
+|:------|:-----|:---------|:--------------|
+| 13 | **Adicionar script lint no backend** | Incluir no package.json e CI | 30 minutos |
+| 14 | **Configurar pre-commit hooks** | Garantir lint e testes antes de commits | 1 hora |
+| 15 | **Revisar cobertura de testes** | Definir metas de cobertura (>80%) | 2-3 horas |
+| 16 | **Documentar padrões de código** | Criar guia de contribuição com padrões | 2-3 horas |
+| 17 | **Implementar CI/CD robusto** | Garantir execução de testes e lint em PRs | 3-4 horas |
+
+### Fase 4: Manutenção Contínua
+
+- **Auditoria mensal de dependências**: Executar `npm audit` e atualizar pacotes
+- **Revisão de PRs**: Implementar processo de revisão obrigatória
+- **Monitoramento de erros**: Integrar ferramenta de monitoramento (Sentry, etc.)
+- **Documentação de decisões**: Manter ADRs (Architecture Decision Records)
+
+---
+
+## 6. Conclusão
+
+O repositório **assist-move-assist** demonstra um grande potencial, com uma arquitetura moderna e uma base de código bem documentada. A escolha de tecnologias (React 18, TypeScript, PostgreSQL, Redis) é apropriada para um sistema de gestão de institutos sociais, e a estrutura de monorepo facilita a manutenção e o desenvolvimento coordenado entre frontend e backend.
+
+Contudo, a dívida técnica acumulada, manifestada em **94 erros de compilação** e **múltiplas vulnerabilidades de segurança**, representa um risco existencial para o projeto. A incapacidade de executar testes automatizados no backend é um sintoma claro de que a qualidade foi comprometida em favor da velocidade de desenvolvimento. O alto volume de *pull requests* focados em correções emergenciais confirma que a equipe já está enfrentando as consequências dessa instabilidade.
+
+A boa notícia é que os problemas identificados são **corrigíveis** e não representam falhas arquiteturais fundamentais. Ao seguir o plano de ação recomendado, a equipe de desenvolvimento pode pagar essa dívida técnica, estabilizar a aplicação e construir uma base sólida para o crescimento futuro do sistema.
+
+A implementação de processos de qualidade mais rigorosos, como a obrigatoriedade do `lint` e a execução de testes em CI, será fundamental para evitar a reincidência desses problemas. Recomenda-se também a criação de um processo formal de rastreamento de issues no GitHub para melhorar a visibilidade e o gerenciamento de problemas conhecidos.
+
+Com as correções implementadas, o projeto estará em condições de evoluir de forma sustentável, mantendo a qualidade, segurança e manutenibilidade necessárias para um sistema crítico de gestão social.
+
+---
+
+**Fim do Relatório**
+


### PR DESCRIPTION
## Summary
- add a Portuguese advanced failure analysis report that captures current technical risks and recommended remediation steps for the repository

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dff4e256c883249d281b9d0dd19650