### PR TITLE
refactor: centralize zod imports

### DIFF
--- a/apps/backend/src/routes/beneficiarias.routes.ts
+++ b/apps/backend/src/routes/beneficiarias.routes.ts
@@ -17,7 +17,7 @@ import {
   validateBeneficiaria
 } from '../validators/beneficiaria.validator';
 import { pool } from '../config/database';
-import { ZodError } from '../openapi/init';
+import { z, ZodError } from '../openapi/init';
 import { redis } from '../lib/redis';
 import { uploadSingle, UPLOAD_DIR } from '../middleware/upload';
 import type { BeneficiariaDetalhada } from '../types/beneficiarias';
@@ -253,10 +253,10 @@ router.post(
   requireProfissional,
   authorize('beneficiarias.criar'),
   validateRequest(
-    require('zod').z.object({
+    z.object({
       body: beneficiariaSchema,
-      query: require('zod').z.any().optional(),
-      params: require('zod').z.any().optional(),
+      query: z.any().optional(),
+      params: z.any().optional(),
     })
   ),
   async (req: ExtendedRequest, res: Response): Promise<void> => {
@@ -302,10 +302,10 @@ router.put(
   requireProfissional,
   authorize('beneficiarias.editar'),
   validateRequest(
-    require('zod').z.object({
+    z.object({
       body: beneficiariaSchema.partial(),
-      query: require('zod').z.any().optional(),
-      params: require('zod').z.any().optional(),
+      query: z.any().optional(),
+      params: z.any().optional(),
     })
   ),
   async (req: ExtendedRequest, res: Response): Promise<void> => {
@@ -384,10 +384,10 @@ router.put(
   requireProfissional,
   authorize('beneficiarias.editar'),
   validateRequest(
-    require('zod').z.object({
+    z.object({
       body: infoSocioeconomicaSchema,
-      query: require('zod').z.any().optional(),
-      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+      query: z.any().optional(),
+      params: z.object({ id: z.string().regex(/^\d+$/) })
     })
   ),
   async (req: ExtendedRequest, res: Response): Promise<void> => {
@@ -432,10 +432,10 @@ router.post(
   requireProfissional,
   authorize('beneficiarias.editar'),
   validateRequest(
-    require('zod').z.object({
+    z.object({
       body: dependenteSchema,
-      query: require('zod').z.any().optional(),
-      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+      query: z.any().optional(),
+      params: z.object({ id: z.string().regex(/^\d+$/) })
     })
   ),
   async (req: ExtendedRequest, res: Response): Promise<void> => {
@@ -506,10 +506,10 @@ router.post(
   requireProfissional,
   authorize('beneficiarias.editar'),
   validateRequest(
-    require('zod').z.object({
+    z.object({
       body: atendimentoSchema,
-      query: require('zod').z.any().optional(),
-      params: require('zod').z.object({ id: require('zod').z.string().regex(/^\d+$/) })
+      query: z.any().optional(),
+      params: z.object({ id: z.string().regex(/^\d+$/) })
     })
   ),
   async (req: ExtendedRequest, res: Response): Promise<void> => {

--- a/apps/frontend/src/config/env.ts
+++ b/apps/frontend/src/config/env.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'src/openapi/init';
 
 const envSchema = z.object({
   VITE_API_BASE_URL: z.string().url('VITE_API_BASE_URL deve ser uma URL válida'),

--- a/apps/frontend/src/hooks/useApi.ts
+++ b/apps/frontend/src/hooks/useApi.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiService } from '@/services/apiService';
 import type { Pagination } from '@/types/api';
 import { toast } from 'sonner';
-import { z } from 'zod';
+import { z } from 'src/openapi/init';
 import { beneficiariaSchema } from '../validation/zodSchemas';
 
 type Beneficiaria = z.infer<typeof beneficiariaSchema>;

--- a/apps/frontend/src/openapi/init.ts
+++ b/apps/frontend/src/openapi/init.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export { z };

--- a/apps/frontend/src/pages/Auth.tsx
+++ b/apps/frontend/src/pages/Auth.tsx
@@ -9,7 +9,7 @@ import { Heart, Eye, EyeOff, Loader2 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
+import { z } from "src/openapi/init";
 
 const loginSchema = z.object({
   email: z.string().email("Email inválido"),

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'src/openapi/init';
 import { beneficiariaSchema } from '../validation/zodSchemas';
 import { apiService, formulariosApi } from '@/services/apiService';
 import type {

--- a/apps/frontend/src/utils/oficinas.ts
+++ b/apps/frontend/src/utils/oficinas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'src/openapi/init';
 import type {
   CreateOficinaDTO,
   Oficina,

--- a/apps/frontend/src/validation/zodSchemas.ts
+++ b/apps/frontend/src/validation/zodSchemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'src/openapi/init';
 
 export const beneficiariaSchema = z.object({
   nome_completo: z.string()

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "src/*": ["./src/*"],
       "@assist/types": ["../../packages/types/src/index.ts"],
       "@assist/types/*": ["../../packages/types/src/*"]
     }

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "src/*": ["./src/*"],
       "@assist/types": ["../../packages/types/src/index.ts"],
       "@assist/types/*": ["../../packages/types/src/*"]
     },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -74,6 +74,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': resolve(__dirname, './src'),
+        src: resolve(__dirname, './src'),
         '@assist/types': resolve(__dirname, '../../packages/types/src'),
       },
     },


### PR DESCRIPTION
## Summary
- add a frontend zod initializer and configure path aliases for `src/*`
- update frontend modules to consume `z` from `src/openapi/init`
- reuse the shared `z` instance in beneficiarias routes instead of local `require` calls

## Testing
- npm run lint:backend *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e017cde7e88324ac768672b48a070c